### PR TITLE
fix: terminal spinner text clearing when status changes

### DIFF
--- a/pkg/cmd/avatar/avatar.go
+++ b/pkg/cmd/avatar/avatar.go
@@ -298,7 +298,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		case <-spinnerTicker.C:
 			// Update spinner animation smoothly
 			frame := spinnerFrames[spinnerIndex%len(spinnerFrames)]
-			fmt.Printf("\r%s Status: %s", frame, currentStatus)
+			fmt.Printf("\r\033[K%s Status: %s", frame, currentStatus)
 			spinnerIndex++
 		}
 	}

--- a/pkg/cmd/image/image.go
+++ b/pkg/cmd/image/image.go
@@ -186,7 +186,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		case <-spinnerTicker.C:
 			// Update spinner animation smoothly
 			frame := spinnerFrames[spinnerIndex%len(spinnerFrames)]
-			fmt.Printf("\r%s Status: %s", frame, currentStatus)
+			fmt.Printf("\r\033[K%s Status: %s", frame, currentStatus)
 			spinnerIndex++
 		}
 	}

--- a/pkg/cmd/video/video.go
+++ b/pkg/cmd/video/video.go
@@ -209,7 +209,7 @@ func runGenerateTalkingAvatar(cmd *cobra.Command, args []string) error {
 		case <-spinnerTicker.C:
 			// Update spinner animation smoothly
 			frame := spinnerFrames[spinnerIndex%len(spinnerFrames)]
-			fmt.Printf("\r%s Status: %s", frame, currentStatus)
+			fmt.Printf("\r\033[K%s Status: %s", frame, currentStatus)
 			spinnerIndex++
 		}
 	}


### PR DESCRIPTION
## Summary

Fixed visual bug in terminal spinner where status text changes would leave trailing characters when status changed from longer to shorter text (e.g., PROCESSING → IN_QUEUE showing as IN_QUEUENG).

## Changes

Added proper ANSI line clearing () escape sequence in all async task spinners:
- Avatar generation ()
- Image generation ()  
- Video talking avatar generation ()

## Testing

The fix ensures that when status changes between different lengths (PROCESSING → IN_QUEUE, etc.), the line is properly cleared before displaying the new status text.