### PR TITLE
feat: enhance avatar build with polling and backgrounding

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ func init() {
 
 func Load() (*Config, error) {
 	cfg := &Config{
-		APIURL:       "https://api.mirako.ai",
+		APIURL:          "https://mirako.co",
 		DefaultModel:    "metis-2.5",
 		DefaultVoice:    "mira-korner",
 		OutputFormat:    "table",
@@ -93,3 +93,4 @@ func (c *Config) Save() error {
 func (c *Config) IsAuthenticated() bool {
 	return c.APIToken != ""
 }
+

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/mirako-ai/mirako-cli/internal/config"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/auth"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/avatar"
@@ -12,6 +11,7 @@ import (
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/image"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/interactive"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/video"
+	"github.com/spf13/cobra"
 )
 
 var cfg *config.Config
@@ -42,7 +42,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("debug", false, "Enable debug mode")
 	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.mirako/config.yml)")
 	rootCmd.PersistentFlags().String("api-token", "", "API token for authentication")
-	rootCmd.PersistentFlags().String("api-url", "", "API URL (default https://api.mirako.ai)")
+	rootCmd.PersistentFlags().String("api-url", "", "API URL (default https://mirako.co)")
 
 	// Add subcommands
 	rootCmd.AddCommand(auth.NewAuthCmd())
@@ -72,4 +72,3 @@ func initConfig() {
 		cfg.APIURL = apiURL
 	}
 }
-


### PR DESCRIPTION
## What's new

**Better avatar build experience**
- Live progress spinner instead of hanging
- Option to background long builds and check later  
- New --poll-interval flag to control refresh speed

**Infrastructure**
- Updated API URL to mirako.co

**Impact**: Users can now build avatars without blocking their terminal, making the CLI much more usable for long-running builds.