### PR TITLE
feat: Add language support to voice profile listings

### DIFF
--- a/internal/api/gen_api.go
+++ b/internal/api/gen_api.go
@@ -460,7 +460,7 @@ type StartSessionApiRequestBody struct {
 	// LlmModel The LLM model to be used for generating avatar's response
 	LlmModel string `json:"llm_model"`
 
-	// Model The interactive model version
+	// Model The interactive model version. The default model used is 'metis-2.5'
 	Model *StartSessionApiRequestBodyModel `json:"model,omitempty"`
 
 	// Tools The tools to be used in the session
@@ -470,7 +470,7 @@ type StartSessionApiRequestBody struct {
 	VoiceProfileId string `json:"voice_profile_id"`
 }
 
-// StartSessionApiRequestBodyModel The interactive model version
+// StartSessionApiRequestBodyModel The interactive model version. The default model used is 'metis-2.5'
 type StartSessionApiRequestBodyModel string
 
 // StartSessionApiResponseBody defines model for StartSessionApiResponseBody.
@@ -567,6 +567,9 @@ type VoiceProfile struct {
 
 	// IsPremade Whether the voice profile is a default premade profile.
 	IsPremade *bool `json:"is_premade,omitempty"`
+
+	// Languages The languages supported by the voice profile.
+	Languages *[]string `json:"languages"`
 
 	// Name The name of the voice profile.
 	Name *string `json:"name,omitempty"`

--- a/pkg/cmd/voice/voice.go
+++ b/pkg/cmd/voice/voice.go
@@ -3,6 +3,7 @@ package voice
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mirako-ai/mirako-cli/internal/api"
@@ -12,6 +13,31 @@ import (
 	"github.com/mirako-ai/mirako-cli/pkg/ui"
 	"github.com/spf13/cobra"
 )
+
+// Language code to friendly label mapping
+var languageLabels = map[string]string{
+	"en":  "English",
+	"yue": "Cantonese", 
+	"zh":  "Mandarin",
+}
+
+// formatLanguages converts language codes to friendly labels
+func formatLanguages(languages *[]string) string {
+	if languages == nil || len(*languages) == 0 {
+		return ""
+	}
+	
+	labels := make([]string, len(*languages))
+	for i, lang := range *languages {
+		if label, ok := languageLabels[lang]; ok {
+			labels[i] = label
+		} else {
+			labels[i] = lang // fallback to original code if no mapping found
+		}
+	}
+	
+	return strings.Join(labels, ", ")
+}
 
 func NewVoiceCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -74,10 +100,12 @@ func runListProfiles(cmd *cobra.Command, args []string) error {
 		if profile.Description != nil {
 			description = *profile.Description
 		}
+		languages := formatLanguages(profile.Languages)
 		t.AddRow([]interface{}{
 			profile.Id,
 			name,
 			description,
+			languages,
 		})
 	}
 	t.Flush()
@@ -129,10 +157,12 @@ func runListCustomProfiles(cmd *cobra.Command, args []string) error {
 		if profile.Description != nil {
 			description = *profile.Description
 		}
+		languages := formatLanguages(profile.Languages)
 		t.AddRow([]interface{}{
 			profile.Id,
 			name,
 			description,
+			languages,
 		})
 	}
 	t.Flush()

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -162,6 +162,6 @@ func NewSessionTable(output io.Writer) *TableWriter {
 // NewVoiceProfileTable creates a table for displaying voice profile information
 func NewVoiceProfileTable(output io.Writer) *TableWriter {
 	t := NewTableWriter(output)
-	t.SetHeader([]string{"ID", "NAME", "DESCRIPTION"})
+	t.SetHeader([]string{"ID", "NAME", "DESCRIPTION", "LANGUAGES"})
 	return t
 }

--- a/spec/openapi-3.0.yaml
+++ b/spec/openapi-3.0.yaml
@@ -50,6 +50,21 @@ components:
         - created_at
         - is_delinquent
       type: object
+    ApiUserMetadata:
+      additionalProperties: false
+      properties:
+        is_delinquent:
+          description: Indicates if the API user is delinquent, e.g., negative credits, unpaid bills
+          example: false
+          type: boolean
+        user_id:
+          description: User ID of the API user
+          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          type: string
+      required:
+        - user_id
+        - is_delinquent
+      type: object
     AsyncBuildApiRequestBody:
       additionalProperties: false
       properties:
@@ -144,6 +159,35 @@ components:
         data:
           $ref: "#/components/schemas/AsyncTaskStatus"
           description: The task status for the avatar generation task
+      type: object
+    AsyncGenerateAvatarWebhookRequestBody:
+      additionalProperties: true
+      properties:
+        delayTime:
+          description: The time taken to process the request
+          format: int64
+          type: integer
+        error:
+          description: The error message if any
+          type: string
+        executionTime:
+          description: The time taken to process the request
+          format: int64
+          type: integer
+        id:
+          description: The id of the request
+          type: string
+        output:
+          $ref: "#/components/schemas/GenerateAvatarOutput"
+          description: The output of the request
+        status:
+          description: The status of the request. Possible values are 'IN_QUEUE', 'IN_PROGRESS', 'COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'
+          type: string
+      required:
+        - id
+        - delayTime
+        - executionTime
+        - status
       type: object
     AsyncGenerateImageApiRequestBody:
       additionalProperties: false
@@ -476,23 +520,12 @@ components:
         - task_id
         - status
       type: object
-    FormFile:
+    GenerateAvatarOutput:
       additionalProperties: false
       properties:
-        ContentType:
+        image:
+          description: The generated avatar image, in base64 format
           type: string
-        Filename:
-          type: string
-        IsSet:
-          type: boolean
-        Size:
-          format: int64
-          type: integer
-      required:
-        - ContentType
-        - IsSet
-        - Size
-        - Filename
       type: object
     GenerateAvatarStatusApiResponseBody:
       additionalProperties: false
@@ -649,6 +682,15 @@ components:
         - task_id
         - status
       type: object
+    GetApiUserMetadataResponseBody:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: "#/components/schemas/ApiUserMetadata"
+          description: API user metadata
+      required:
+        - data
+      type: object
     GetAvatarApiResponseBody:
       additionalProperties: false
       properties:
@@ -733,6 +775,10 @@ components:
           description: The interactive model version to be launched.
           example: metis-2.5
           type: string
+        opts:
+          additionalProperties: {}
+          description: Additional options for the instance launch, such as countryCode, gpuTypeIds etc
+          type: object
         session_group:
           description: The session group name for the instance. Default session group will be used if it left unspecfied or empty.
           example: default
@@ -977,7 +1023,8 @@ components:
           example: gemini-2.0-flash
           type: string
         model:
-          description: The interactive model version
+          default: metis-2.5
+          description: The interactive model version. The default model used is 'metis-2.5'
           enum:
             - metis-2.5
           example: metis-2.5
@@ -1181,6 +1228,15 @@ components:
           description: Whether the voice profile is a default premade profile.
           example: true
           type: boolean
+        languages:
+          description: The languages supported by the voice profile.
+          example:
+            - en
+            - yue
+          items:
+            type: string
+          nullable: true
+          type: array
         name:
           description: The name of the voice profile.
           example: Mira Korner


### PR DESCRIPTION
## Summary

This PR adds language support display to voice profile listings in the Mirako CLI.

- Updated to latest OpenAPI spec with language support for voice profiles
- Added Languages field to VoiceProfile struct in generated API code
- Enhanced both voice list commands to display language support tags
- Added friendly language labels mapping:
  - en → English
  - yue → Cantonese  
  - zh → Mandarin
- Updated UI table to include LANGUAGES column
- Applied changes to both 'mirako voice list' and 'mirako voice premade' commands

## Changes

- `spec/openapi-3.0.yaml`: Updated to latest API spec
- `internal/api/gen_api.go`: Regenerated with new VoiceProfile.Languages field
- `pkg/cmd/voice/voice.go`: Added language mapping and formatting logic
- `pkg/ui/table.go`: Updated voice profile table to include languages column

## Testing

- Built successfully with `go build`
- Verified with `go vet ./...`
- Both voice list commands now display language support with friendly labels