### PR TITLE
feat: Add default interactive profile to config initialization

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,7 +48,11 @@ func Load() (*Config, error) {
 		DefaultModel:        "metis-2.5",
 		DefaultVoice:        "",
 		DefaultSavePath:     ".",
-		InteractiveProfiles: make(map[string]InteractiveProfile),
+		InteractiveProfiles: map[string]InteractiveProfile{
+			"default": {
+				Model: "metis-2.5",
+			},
+		},
 	}
 
 	// Create config directory if it doesn't exist


### PR DESCRIPTION
## Summary

This PR adds a default interactive profile to the config initialization, enabling new users to run `mirako interactive start` immediately without manually creating profiles.

## Changes

- Added default interactive profile with `model: metis-2.5` to config initialization in `internal/config/config.go`
- New users can now run `mirako interactive start` out of the box
- Default profile includes only the model field as requested
- Other required fields (avatar_id, voice_profile_id) still need to be provided via CLI flags
- Maintains backward compatibility with existing config files

## Problem Solved

Previously, when users tried to run `mirako interactive start` without creating a profile first, they would get an error message requiring manual profile creation. Now, a default profile is automatically created when the config file is first initialized.

## Testing

- Verified that fresh config initialization creates the default profile correctly
- Build and vet checks pass
- The interactive command will now find a default profile when config is first created

## Implementation Details

The default profile is created with minimal configuration:
```yaml
interactive_profiles:
  default:
    model: metis-2.5
```

Users still need to provide avatar_id and voice_profile_id through CLI flags or by updating their config, but they can now get started with the interactive feature more easily.