### PR TITLE
feat: Add idle_timeout support to interactive sessions

### DIFF
--- a/internal/api/gen_api.go
+++ b/internal/api/gen_api.go
@@ -451,7 +451,7 @@ type StartSessionApiRequestBody struct {
 	// AvatarId The avatar id
 	AvatarId string `json:"avatar_id"`
 
-	// IdleTimeout Idle timeout in mins
+	// IdleTimeout Idle timeout in mins. The default value is 15 minutes if not specified. Setting it to -1 will disable the idle timeout, making the session never auto-terminate due to inactivity.
 	IdleTimeout *int64 `json:"idle_timeout,omitempty"`
 
 	// Instruction The instruction prompt for the avatar in the session

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,12 +10,13 @@ import (
 )
 
 type InteractiveProfile struct {
-	AvatarID       string `mapstructure:"avatar_id" yaml:"avatar_id"`
-	Model          string `mapstructure:"model" yaml:"model"`
-	LLMModel       string `mapstructure:"llm_model" yaml:"llm_model"`
-	VoiceProfileID string `mapstructure:"voice_profile_id" yaml:"voice_profile_id"`
-	Instruction    string `mapstructure:"instruction" yaml:"instruction"`
-	Tools          string `mapstructure:"tools" yaml:"tools"`
+	AvatarID       string  `mapstructure:"avatar_id" yaml:"avatar_id"`
+	Model          string  `mapstructure:"model" yaml:"model"`
+	LLMModel       string  `mapstructure:"llm_model" yaml:"llm_model"`
+	VoiceProfileID string  `mapstructure:"voice_profile_id" yaml:"voice_profile_id"`
+	Instruction    string  `mapstructure:"instruction" yaml:"instruction"`
+	Tools          string  `mapstructure:"tools" yaml:"tools"`
+	IdleTimeout    int64   `mapstructure:"idle_timeout" yaml:"idle_timeout"`
 }
 
 type Config struct {
@@ -48,7 +49,12 @@ func Load() (*Config, error) {
 		DefaultModel:        "metis-2.5",
 		DefaultVoice:        "",
 		DefaultSavePath:     ".",
-		InteractiveProfiles: make(map[string]InteractiveProfile),
+		InteractiveProfiles: map[string]InteractiveProfile{
+			"default": {
+				Model:       "metis-2.5",
+				IdleTimeout: 15,
+			},
+		},
 	}
 
 	// Create config directory if it doesn't exist

--- a/spec/openapi-3.0.yaml
+++ b/spec/openapi-3.0.yaml
@@ -1010,13 +1010,16 @@ components:
       properties:
         avatar_id:
           description: The avatar id
+          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
         idle_timeout:
-          description: Idle timeout in mins
+          description: Idle timeout in mins. The default value is 15 minutes if not specified. Setting it to -1 will disable the idle timeout, making the session never auto-terminate due to inactivity.
+          example: 15
           format: int64
           type: integer
         instruction:
           description: The instruction prompt for the avatar in the session
+          example: You are a helpful assistant.
           type: string
         llm_model:
           description: The LLM model to be used for generating avatar's response
@@ -1034,6 +1037,7 @@ components:
           type: string
         voice_profile_id:
           description: The voice profile id
+          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
       required:
         - avatar_id


### PR DESCRIPTION
## Summary

This PR adds comprehensive idle_timeout support to the Mirako CLI interactive sessions, allowing users to control session auto-termination due to inactivity.

## Changes

- **API Update**: Updated to latest OpenAPI spec with enhanced idle_timeout description
- **Core Support**: Added IdleTimeout field to StartSessionApiRequestBody and InteractiveProfile structs
- **CLI Flag**: Added --idle-timeout flag (short: -t) to 'mirako interactive start' command
- **Default Profile**: Updated default profile to include idle_timeout: 15 minutes
- **Smart Logic**: Implemented proper flag precedence (CLI > profile > default)

## Key Features

- **Unit**: Minutes (as per API specification)
- **Default**: 15 minutes (matches API default)
- **Disable**: Set to -1 to disable idle timeout completely
- **Priority**: CLI flag > profile value > default value
- **Backward Compatible**: Existing configurations continue to work unchanged

## Usage Examples

```bash
# 30 minute timeout
mirako interactive start --idle-timeout 30

# Disable timeout completely
mirako interactive start --idle-timeout -1

# 5 minutes using short flag
mirako interactive start -t 5

# Use profile value (if flag not specified)
mirako interactive start
```

## Implementation Details

The implementation follows the existing pattern where:
- CLI flags override profile values
- Profile values are used when flag is at default (15) and profile has a custom value
- API only receives non-default values when explicitly set or changed

This ensures backward compatibility while providing full control over session timeout behavior.

## Testing

- ✅ Build passes successfully
- ✅ `go vet` checks pass
- ✅ Help output shows new flag with proper description
- ✅ Default profile includes 15-minute timeout
- ✅ Fresh config initialization works correctly

The feature enables users to have better control over their interactive sessions, preventing unexpected terminations or allowing for long-running sessions when needed.