### PR TITLE
feat: Update API spec and fix interactive session compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 # AI agent files
 .claude/
 CLAUDE.local.md
+CLAUDE.md

--- a/internal/api/gen_api.go
+++ b/internal/api/gen_api.go
@@ -352,7 +352,7 @@ type GetAvatarApiResponseBody struct {
 // GetPremadeProfilesApiResponseBody defines model for GetPremadeProfilesApiResponseBody.
 type GetPremadeProfilesApiResponseBody struct {
 	// Data List of premade voice profiles
-	Data *[]VoiceProfile `json:"data"`
+	Data *[]PresignedVoiceProfile `json:"data"`
 }
 
 // GetSessionProfileApiResponseBody defines model for GetSessionProfileApiResponseBody.
@@ -368,13 +368,13 @@ type GetUserAvatarListApiResponseBody struct {
 
 // GetVoiceProfileApiResponseBody defines model for GetVoiceProfileApiResponseBody.
 type GetVoiceProfileApiResponseBody struct {
-	Data VoiceProfile `json:"data"`
+	Data PresignedVoiceProfile `json:"data"`
 }
 
 // GetVoiceProfilesApiResponseBody defines model for GetVoiceProfilesApiResponseBody.
 type GetVoiceProfilesApiResponseBody struct {
 	// Data List of user custom voice profiles
-	Data *[]VoiceProfile `json:"data"`
+	Data *[]PresignedVoiceProfile `json:"data"`
 }
 
 // ListSessionsApiResponseBody defines model for ListSessionsApiResponseBody.
@@ -385,12 +385,34 @@ type ListSessionsApiResponseBody struct {
 
 // MetisSession defines model for MetisSession.
 type MetisSession struct {
-	DesiredState *string   `json:"desired_state"`
-	MetisModel   string    `json:"metis_model"`
-	SessionId    string    `json:"session_id"`
-	StartTime    time.Time `json:"start_time"`
-	State        *string   `json:"state"`
-	UserId       string    `json:"user_id"`
+	Avatar MetisSessionAvatar `json:"avatar"`
+
+	// IdleTimeout Idle timeout duration in minutes
+	IdleTimeout *int64 `json:"idle_timeout,omitempty"`
+
+	// MetisModel The Metis model used in the session
+	MetisModel *string `json:"metis_model,omitempty"`
+
+	// SessionId Unique identifier for the session
+	SessionId *string `json:"session_id,omitempty"`
+
+	// StartTime Timestamp when the session started in RFC3339 format
+	StartTime time.Time `json:"start_time"`
+
+	// State Current state of the session
+	State *string `json:"state,omitempty"`
+
+	// UserId User ID of the session owner
+	UserId *string `json:"user_id,omitempty"`
+}
+
+// MetisSessionAvatar defines model for MetisSessionAvatar.
+type MetisSessionAvatar struct {
+	// Id Unique identifier for the avatar
+	Id *string `json:"id,omitempty"`
+
+	// Name Name of the avatar
+	Name *string `json:"name,omitempty"`
 }
 
 // MetisSessionProfile defines model for MetisSessionProfile.
@@ -418,6 +440,36 @@ type PresignedAvatarTheme struct {
 
 	// Name Name of the avatar theme
 	Name string `json:"name"`
+}
+
+// PresignedVoiceProfile defines model for PresignedVoiceProfile.
+type PresignedVoiceProfile struct {
+	// CreatedAt The creation date of the voice profile.
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+
+	// Description The description of the voice profile.
+	Description *string `json:"description,omitempty"`
+
+	// Id The unique identifier for the voice profile.
+	Id string `json:"id"`
+
+	// IsPremade Whether the voice profile is a default premade profile.
+	IsPremade *bool `json:"is_premade,omitempty"`
+
+	// Languages The languages supported by the voice profile.
+	Languages *[]string `json:"languages"`
+
+	// Name The name of the voice profile.
+	Name *string `json:"name,omitempty"`
+
+	// SampleClip The URL of a sample audio clip for the voice profile.
+	SampleClip *string `json:"sample_clip,omitempty"`
+
+	// Status The status of the voice profile.
+	Status *string `json:"status,omitempty"`
+
+	// UserId The user ID of the owner associated with the voice profile.
+	UserId *string `json:"user_id,omitempty"`
 }
 
 // STTApiRequestBody defines model for STTApiRequestBody.
@@ -552,36 +604,6 @@ type TTSParams struct {
 
 	// Temperature The temperature for the TTS model, controls the randomness of the output. Default is 1.0.
 	Temperature *float32 `json:"temperature,omitempty"`
-}
-
-// VoiceProfile defines model for VoiceProfile.
-type VoiceProfile struct {
-	// CreatedAt The creation date of the voice profile.
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-
-	// Description The description of the voice profile.
-	Description *string `json:"description,omitempty"`
-
-	// Id The unique identifier for the voice profile.
-	Id string `json:"id"`
-
-	// IsPremade Whether the voice profile is a default premade profile.
-	IsPremade *bool `json:"is_premade,omitempty"`
-
-	// Languages The languages supported by the voice profile.
-	Languages *[]string `json:"languages"`
-
-	// Name The name of the voice profile.
-	Name *string `json:"name,omitempty"`
-
-	// SampleClip The URL of a sample audio clip for the voice profile.
-	SampleClip *string `json:"sample_clip,omitempty"`
-
-	// Status The status of the voice profile.
-	Status *string `json:"status,omitempty"`
-
-	// UserId The user ID of the owner associated with the voice profile.
-	UserId *string `json:"user_id,omitempty"`
 }
 
 // Webhook defines model for Webhook.

--- a/pkg/cmd/avatar/avatar.go
+++ b/pkg/cmd/avatar/avatar.go
@@ -263,7 +263,9 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 					// Determine output path
 					if outputPath == "" {
-						defaultFilename := fmt.Sprintf("avatar_%s.jpg", time.Now().Format("20060102_150405"))
+						now := time.Now()
+						timestamp := fmt.Sprintf("%s_%03d", now.Format("20060102_150405"), now.Nanosecond()/1000000)
+						defaultFilename := fmt.Sprintf("avatar_%s.jpg", timestamp)
 						outputPath = filepath.Join(cfg.DefaultSavePath, defaultFilename)
 					}
 

--- a/pkg/cmd/image/image.go
+++ b/pkg/cmd/image/image.go
@@ -147,7 +147,9 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 					// Determine output path
 					if outputPath == "" {
-						defaultFilename := fmt.Sprintf("image_%s.jpg", time.Now().Format("20060102_150405"))
+						now := time.Now()
+						timestamp := fmt.Sprintf("%s_%03d", now.Format("20060102_150405"), now.Nanosecond()/1000000)
+						defaultFilename := fmt.Sprintf("image_%s.jpg", timestamp)
 						outputPath = filepath.Join(cfg.DefaultSavePath, defaultFilename)
 					}
 
@@ -303,4 +305,3 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-

--- a/pkg/cmd/interactive/interactive.go
+++ b/pkg/cmd/interactive/interactive.go
@@ -82,16 +82,20 @@ func runList(cmd *cobra.Command, args []string) error {
 			state = *session.State
 		}
 
-		desiredState := ""
-		if session.DesiredState != nil {
-			desiredState = *session.DesiredState
+		sessionId := ""
+		if session.SessionId != nil {
+			sessionId = *session.SessionId
+		}
+
+		model := ""
+		if session.MetisModel != nil {
+			model = *session.MetisModel
 		}
 
 		t.AddRow([]interface{}{
-			session.SessionId,
-			session.MetisModel,
+			sessionId,
+			model,
 			state,
-			desiredState,
 			ui.FormatTimestamp(session.StartTime),
 		})
 	}
@@ -268,15 +272,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if profileName != "" {
 		fmt.Printf("   Profile: %s\n", profileName)
 	}
-	fmt.Printf("   Session ID: %s\n", resp.Data.Session.SessionId)
-	fmt.Printf("   Model: %s\n", resp.Data.Session.MetisModel)
+	fmt.Printf("   Session ID: %s\n", *resp.Data.Session.SessionId)
+	fmt.Printf("   Model: %s\n", *resp.Data.Session.MetisModel)
 	fmt.Printf("   LLM Model: %s\n", llmModel)
 	fmt.Printf("   Voice: %s\n", voiceID)
 	fmt.Printf("You can use the following token for interactive api calls:\n   %s", resp.Data.SessionToken)
 	fmt.Println()
 	fmt.Println()
 	// try open the url in default browser
-	url := fmt.Sprintf("https://interactive.mirako.ai/i/%s", resp.Data.Session.SessionId)
+	url := fmt.Sprintf("https://interactive.mirako.ai/i/%s", *resp.Data.Session.SessionId)
 	if err = utils.OpenURLAndForget(url); err != nil {
 		// use test hint instead
 		fmt.Printf("You can now visit the url: %s", url)

--- a/pkg/cmd/video/video.go
+++ b/pkg/cmd/video/video.go
@@ -160,7 +160,9 @@ func runGenerateTalkingAvatar(cmd *cobra.Command, args []string) error {
 
 					// Determine output path
 					if outputPath == "" {
-						defaultFilename := fmt.Sprintf("video_%s.mp4", time.Now().Format("20060102_150405"))
+						now := time.Now()
+						timestamp := fmt.Sprintf("%s_%03d", now.Format("20060102_150405"), now.Nanosecond()/1000000)
+						defaultFilename := fmt.Sprintf("video_%s.mp4", timestamp)
 						outputPath = filepath.Join(cfg.DefaultSavePath, defaultFilename)
 					}
 
@@ -337,4 +339,3 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -155,7 +155,7 @@ func NewAvatarTable(output io.Writer) *TableWriter {
 // NewSessionTable creates a table for displaying session information
 func NewSessionTable(output io.Writer) *TableWriter {
 	t := NewTableWriter(output)
-	t.SetHeader([]string{"SESSION ID", "MODEL", "STATE", "DESIRED STATE", "START TIME"})
+	t.SetHeader([]string{"SESSION ID", "MODEL", "STATE", "START TIME"})
 	return t
 }
 

--- a/spec/openapi-3.0.yaml
+++ b/spec/openapi-3.0.yaml
@@ -458,6 +458,18 @@ components:
           format: uri
           type: string
       type: object
+    FinetuningMetadata:
+      additionalProperties: false
+      properties:
+        Extra:
+          additionalProperties: {}
+          type: object
+        ref_audio:
+          $ref: "#/components/schemas/RemoteFile"
+          description: A sample clip of the finetuned voice model for preview purpose.
+      required:
+        - Extra
+      type: object
     FinetuningOutputInternal:
       additionalProperties: false
       properties:
@@ -466,9 +478,8 @@ components:
         id:
           type: string
         meta_data:
-          additionalProperties: {}
+          $ref: "#/components/schemas/FinetuningMetadata"
           description: Additional metadata about the finetuning process
-          type: object
         model_infer_params:
           additionalProperties: {}
           description: The inference parameters for the model
@@ -715,7 +726,7 @@ components:
         data:
           description: List of premade voice profiles
           items:
-            $ref: "#/components/schemas/VoiceProfile"
+            $ref: "#/components/schemas/PresignedVoiceProfile"
           nullable: true
           type: array
       required:
@@ -732,7 +743,7 @@ components:
       additionalProperties: false
       properties:
         data:
-          $ref: "#/components/schemas/VoiceSystemProfile"
+          $ref: "#/components/schemas/PresignedVoiceSystemProfile"
           description: The voice system profile
       type: object
     GetUserAvatarListApiResponseBody:
@@ -751,7 +762,7 @@ components:
       additionalProperties: false
       properties:
         data:
-          $ref: "#/components/schemas/VoiceProfile"
+          $ref: "#/components/schemas/PresignedVoiceProfile"
           description: Voice profile data
       required:
         - data
@@ -762,7 +773,7 @@ components:
         data:
           description: List of user custom voice profiles
           items:
-            $ref: "#/components/schemas/VoiceProfile"
+            $ref: "#/components/schemas/PresignedVoiceProfile"
           nullable: true
           type: array
       required:
@@ -858,28 +869,42 @@ components:
     MetisSession:
       additionalProperties: false
       properties:
-        desired_state:
-          nullable: true
-          type: string
+        avatar:
+          $ref: "#/components/schemas/MetisSessionAvatar"
+          description: Details of the avatar used in the session
+        idle_timeout:
+          description: Idle timeout duration in minutes
+          format: int64
+          type: integer
         metis_model:
+          description: The Metis model used in the session
           type: string
         session_id:
+          description: Unique identifier for the session
           type: string
         start_time:
+          description: Timestamp when the session started in RFC3339 format
           format: date-time
           type: string
         state:
-          nullable: true
+          description: Current state of the session
           type: string
         user_id:
+          description: User ID of the session owner
           type: string
       required:
-        - session_id
-        - user_id
-        - metis_model
-        - state
-        - desired_state
+        - avatar
         - start_time
+      type: object
+    MetisSessionAvatar:
+      additionalProperties: false
+      properties:
+        id:
+          description: Unique identifier for the avatar
+          type: string
+        name:
+          description: Name of the avatar
+          type: string
       type: object
     MetisSessionProfile:
       additionalProperties: false
@@ -930,6 +955,107 @@ components:
           type: string
       required:
         - name
+      type: object
+    PresignedVoiceProfile:
+      additionalProperties: false
+      properties:
+        created_at:
+          description: The creation date of the voice profile.
+          example: "2023-10-01T12:00:00Z"
+          format: date-time
+          type: string
+        description:
+          description: The description of the voice profile.
+          example: A friendly and professional voice for customer support.
+          type: string
+        id:
+          description: The unique identifier for the voice profile.
+          type: string
+        is_premade:
+          description: Whether the voice profile is a default premade profile.
+          example: true
+          type: boolean
+        languages:
+          description: The languages supported by the voice profile.
+          example:
+            - en
+            - yue
+          items:
+            type: string
+          nullable: true
+          type: array
+        name:
+          description: The name of the voice profile.
+          example: Mira Korner
+          type: string
+        sample_clip:
+          description: The URL of a sample audio clip for the voice profile.
+          example: https://example.com/sample.mp3
+          type: string
+        status:
+          description: The status of the voice profile.
+          example: READY
+          type: string
+        user_id:
+          description: The user ID of the owner associated with the voice profile.
+          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          type: string
+      required:
+        - id
+      type: object
+    PresignedVoiceSystemProfile:
+      additionalProperties: false
+      properties:
+        created_at:
+          description: The creation date of the voice profile.
+          example: "2023-10-01T12:00:00Z"
+          format: date-time
+          type: string
+        description:
+          description: The description of the voice profile.
+          example: A friendly and professional voice for customer support.
+          type: string
+        id:
+          description: The unique identifier for the voice profile.
+          type: string
+        is_premade:
+          description: Whether the voice profile is a default premade profile.
+          example: true
+          type: boolean
+        languages:
+          description: The languages supported by the voice profile.
+          example:
+            - en
+            - yue
+          items:
+            type: string
+          nullable: true
+          type: array
+        name:
+          description: The name of the voice profile.
+          example: Mira Korner
+          type: string
+        params:
+          additionalProperties: {}
+          description: The parameters used for the voice model.
+          type: object
+        sample_clip:
+          description: The URL of a sample audio clip for the voice profile.
+          example: https://example.com/sample.mp3
+          type: string
+        service_name:
+          description: The name of the voice service used for this profile.
+          type: string
+        status:
+          description: The status of the voice profile.
+          example: READY
+          type: string
+        user_id:
+          description: The user ID of the owner associated with the voice profile.
+          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          type: string
+      required:
+        - id
       type: object
     PrivateApiResponseBody:
       additionalProperties: false
@@ -1212,73 +1338,6 @@ components:
           type: array
       required:
         - terminated_instances
-      type: object
-    VoiceProfile:
-      additionalProperties: false
-      properties:
-        created_at:
-          description: The creation date of the voice profile.
-          example: "2023-10-01T12:00:00Z"
-          format: date-time
-          type: string
-        description:
-          description: The description of the voice profile.
-          example: A friendly and professional voice for customer support.
-          type: string
-        id:
-          description: The unique identifier for the voice profile.
-          type: string
-        is_premade:
-          description: Whether the voice profile is a default premade profile.
-          example: true
-          type: boolean
-        languages:
-          description: The languages supported by the voice profile.
-          example:
-            - en
-            - yue
-          items:
-            type: string
-          nullable: true
-          type: array
-        name:
-          description: The name of the voice profile.
-          example: Mira Korner
-          type: string
-        sample_clip:
-          description: The URL of a sample audio clip for the voice profile.
-          example: https://example.com/sample.mp3
-          type: string
-        status:
-          description: The status of the voice profile.
-          example: READY
-          type: string
-        user_id:
-          description: The user ID of the owner associated with the voice profile.
-          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
-          type: string
-      required:
-        - id
-      type: object
-    VoiceSystemProfile:
-      additionalProperties: false
-      properties:
-        id:
-          description: The unique identifier for the voice profile.
-          type: string
-        name:
-          description: The name of the voice profile.
-          example: Mira Korner
-          type: string
-        params:
-          additionalProperties: {}
-          description: The parameters used for the voice model.
-          type: object
-        service_name:
-          description: The name of the voice service used for this profile.
-          type: string
-      required:
-        - id
       type: object
     Webhook:
       additionalProperties: false


### PR DESCRIPTION
## Summary

This PR updates the Mirako CLI to be compatible with the latest API changes:

### Changes Made:
- **API Spec Update**: Updated OpenAPI 3.0 specification to the latest version from mirako.co
- **Client Code Regeneration**: Regenerated Go client code using oapi-codegen
- **Interactive Session Fixes**: 
  - Removed `DesiredState` field usage (no longer exists in `MetisSession` struct)
  - Fixed pointer dereferencing for `SessionId` and `MetisModel` fields (now `*string`)
  - Updated session table to remove 'DESIRED STATE' column
- **Backward Compatibility**: Ensured all existing interactive commands continue to work

### Technical Details:
- The `MetisSession` struct in the new API no longer includes a `DesiredState` field
- Session ID and model fields are now pointers to strings instead of direct strings
- Table display updated to show only current state, session ID, model, and start time

### Testing:
- All existing tests pass
- Code compiles successfully with `go build`
- No linting issues with `go vet`

This update ensures the CLI remains compatible with the latest Mirako API while maintaining all existing functionality.