### PR TITLE
feat: add Homebrew support via Goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,6 +69,25 @@ github_urls:
 metadata:
   mod_timestamp: '{{ .CommitTimestamp }}'
 
+# Homebrew tap configuration
+brews:
+  - name: mirako
+    repository:
+      owner: mirako-ai
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://mirako.ai"
+    description: "Official CLI for Mirako AI platform - Create and manage AI avatars, interactive sessions, and AI media generation"
+    license: "MIT"
+    dependencies:
+      - name: git
+        type: optional
+    install: |
+      bin.install "mirako"
+    test: |
+      system "#{bin}/mirako --version"
+
 # Environment
 env:
   - CGO_ENABLED=0

--- a/README.md
+++ b/README.md
@@ -17,25 +17,41 @@ The official CLI interface for the [Mirako AI](https://mirako.ai) platform, main
 
 ## Installation
 
-### Option 1: Pre-built Binary (Recommended)
+### Option 1: Homebrew (macOS & Linux - Recommended)
 
-Download the latest release for your platform from GitHub Releases.
+```bash
+# Add the Mirako tap
+brew tap mirako-ai/tap
+
+# Install Mirako CLI
+brew install mirako
+```
+
+### Option 2: Pre-built Binary
+
+Download the latest release for your platform from [GitHub Releases](https://github.com/mirako-ai/mirako-cli/releases).
 
 ```bash
 # macOS (Apple Silicon)
-wget https://github.com/mirako-ai/mirako-cli/releases/latest/download/mirako-darwin-arm64.tar.gz
-tar -xzf mirako-darwin-arm64.tar.gz
+wget https://github.com/mirako-ai/mirako-cli/releases/latest/download/mirako_Darwin_arm64.tar.gz
+tar -xzf mirako_Darwin_arm64.tar.gz
+chmod +x mirako
+sudo mv mirako /usr/local/bin/mirako
+
+# macOS (Intel)
+wget https://github.com/mirako-ai/mirako-cli/releases/latest/download/mirako_Darwin_x86_64.tar.gz
+tar -xzf mirako_Darwin_x86_64.tar.gz
 chmod +x mirako
 sudo mv mirako /usr/local/bin/mirako
 
 # Linux
-wget https://github.com/mirako-ai/mirako-cli/releases/latest/download/mirako-linux-amd64.tar.gz
-tar -xzf mirako-linux-amd64.tar.gz
+wget https://github.com/mirako-ai/mirako-cli/releases/latest/download/mirako_Linux_x86_64.tar.gz
+tar -xzf mirako_Linux_x86_64.tar.gz
 chmod +x mirako
 sudo mv mirako /usr/local/bin/mirako
 
 # Windows
-# Download mirako-windows-amd64.exe from releases and add to PATH
+# Download mirako_Windows_x86_64.zip from releases, extract, and add mirako.exe to PATH
 ```
 
 Afterwards, you can run `mirako` to verify the installation.


### PR DESCRIPTION
## Summary

This PR adds Homebrew support to the Mirako CLI using Goreleaser's built-in Homebrew tap management.

### Changes Made:

#### 🔧 Goreleaser Configuration
- Added `brews` section with complete Homebrew tap configuration
- Configured automatic formula generation and updates
- Set up proper metadata (homepage, description, license)
- Added test commands for formula validation

#### 📚 Documentation Update
- Promoted Homebrew as primary installation method for macOS & Linux
- Updated README with `brew tap mirako-ai/tap && brew install mirako`
- Moved pre-built binaries to secondary option

### Prerequisites for You:

#### 1. Create Homebrew Tap Repository
Create `mirako-ai/homebrew-tap` repository with basic Formula/ directory

#### 2. Add GitHub Token Secret
Add `HOMEBREW_TAP_GITHUB_TOKEN` to repository secrets with repo scope

#### 3. Grant Repository Access
Ensure CI token can push to the tap repository

### User Experience:
**Before:** Manual download and install
**After:** `brew install mirako` (after tapping)

Ready for testing once tap repository is created!