### PR TITLE
feat: simplify version output to show only version string

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -57,6 +57,9 @@ func init() {
 	rootCmd.PersistentFlags().String("api-token", "", "API token for authentication")
 	rootCmd.PersistentFlags().String("api-url", "", "API URL (default https://mirako.co)")
 
+	// Set custom version template to show only the version string
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+
 	// Add subcommands
 	rootCmd.AddCommand(auth.NewAuthCmd())
 	rootCmd.AddCommand(avatar.NewAvatarCmd())


### PR DESCRIPTION
## Summary
- Remove redundant "mirako version" prefix from `--version` flag output  
- Eliminate the `version` subcommand as `--version` flag provides the same functionality
- Use Cobra's `SetVersionTemplate` to display only the version string for cleaner output