### PR TITLE
update interactive instruction to 12k characters matching with Mirako API; added voice description field

### DIFF
--- a/internal/api/gen_api.go
+++ b/internal/api/gen_api.go
@@ -61,6 +61,16 @@ const (
 	FinetuningTaskOutputStatusTIMEDOUT   FinetuningTaskOutputStatus = "TIMED_OUT"
 )
 
+// Defines values for GenerateAvatarMotionTaskOutputStatus.
+const (
+	GenerateAvatarMotionTaskOutputStatusCANCELED   GenerateAvatarMotionTaskOutputStatus = "CANCELED"
+	GenerateAvatarMotionTaskOutputStatusCOMPLETED  GenerateAvatarMotionTaskOutputStatus = "COMPLETED"
+	GenerateAvatarMotionTaskOutputStatusFAILED     GenerateAvatarMotionTaskOutputStatus = "FAILED"
+	GenerateAvatarMotionTaskOutputStatusINPROGRESS GenerateAvatarMotionTaskOutputStatus = "IN_PROGRESS"
+	GenerateAvatarMotionTaskOutputStatusINQUEUE    GenerateAvatarMotionTaskOutputStatus = "IN_QUEUE"
+	GenerateAvatarMotionTaskOutputStatusTIMEDOUT   GenerateAvatarMotionTaskOutputStatus = "TIMED_OUT"
+)
+
 // Defines values for GenerateAvatarTaskOutputStatus.
 const (
 	GenerateAvatarTaskOutputStatusCANCELED   GenerateAvatarTaskOutputStatus = "CANCELED"
@@ -83,12 +93,12 @@ const (
 
 // Defines values for GenerateTaskOutputStatus.
 const (
-	CANCELED   GenerateTaskOutputStatus = "CANCELED"
-	COMPLETED  GenerateTaskOutputStatus = "COMPLETED"
-	FAILED     GenerateTaskOutputStatus = "FAILED"
-	INPROGRESS GenerateTaskOutputStatus = "IN_PROGRESS"
-	INQUEUE    GenerateTaskOutputStatus = "IN_QUEUE"
-	TIMEDOUT   GenerateTaskOutputStatus = "TIMED_OUT"
+	GenerateTaskOutputStatusCANCELED   GenerateTaskOutputStatus = "CANCELED"
+	GenerateTaskOutputStatusCOMPLETED  GenerateTaskOutputStatus = "COMPLETED"
+	GenerateTaskOutputStatusFAILED     GenerateTaskOutputStatus = "FAILED"
+	GenerateTaskOutputStatusINPROGRESS GenerateTaskOutputStatus = "IN_PROGRESS"
+	GenerateTaskOutputStatusINQUEUE    GenerateTaskOutputStatus = "IN_QUEUE"
+	GenerateTaskOutputStatusTIMEDOUT   GenerateTaskOutputStatus = "TIMED_OUT"
 )
 
 // Defines values for StartSessionApiRequestBodyModel.
@@ -139,6 +149,27 @@ type AsyncGenerateAvatarApiRequestBody struct {
 
 // AsyncGenerateAvatarApiResponseBody defines model for AsyncGenerateAvatarApiResponseBody.
 type AsyncGenerateAvatarApiResponseBody struct {
+	Data *AsyncTaskStatus `json:"data,omitempty"`
+}
+
+// AsyncGenerateAvatarMotionApiRequestBody defines model for AsyncGenerateAvatarMotionApiRequestBody.
+type AsyncGenerateAvatarMotionApiRequestBody struct {
+	// Audio The base64 encoded audio file to use as the avatar's speech.
+	Audio string `json:"audio"`
+
+	// Image The base64 encoded image to use as the starting frame, which should clearly showing the avatar's face.
+	Image string `json:"image"`
+
+	// NegativePrompt The negative prompt to guide the avatar motion generation.
+	NegativePrompt string `json:"negative_prompt"`
+
+	// PositivePrompt The positive prompt to guide the avatar motion generation.
+	PositivePrompt string   `json:"positive_prompt"`
+	Webhook        *Webhook `json:"webhook,omitempty"`
+}
+
+// AsyncGenerateAvatarMotionApiResponseBody defines model for AsyncGenerateAvatarMotionApiResponseBody.
+type AsyncGenerateAvatarMotionApiResponseBody struct {
 	Data *AsyncTaskStatus `json:"data,omitempty"`
 }
 
@@ -281,6 +312,32 @@ type FinetuningTaskOutput struct {
 // FinetuningTaskOutputStatus The status of the async task. Possible values are 'IN_QUEUE', 'IN_PROGRESS', 'COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'
 type FinetuningTaskOutputStatus string
 
+// GenerateAvatarMotionStatusApiResponseBody defines model for GenerateAvatarMotionStatusApiResponseBody.
+type GenerateAvatarMotionStatusApiResponseBody struct {
+	Data *GenerateAvatarMotionTaskOutput `json:"data,omitempty"`
+}
+
+// GenerateAvatarMotionTaskOutput defines model for GenerateAvatarMotionTaskOutput.
+type GenerateAvatarMotionTaskOutput struct {
+	// Error Error message if any
+	Error *string `json:"error,omitempty"`
+
+	// FileUrl The URL of the output MP4 video.
+	FileUrl *string `json:"file_url,omitempty"`
+
+	// OutputDuration The duration of the output video in seconds.
+	OutputDuration *float64 `json:"output_duration,omitempty"`
+
+	// Status The status of the async task. Possible values are 'IN_QUEUE', 'IN_PROGRESS', 'COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'
+	Status GenerateAvatarMotionTaskOutputStatus `json:"status"`
+
+	// TaskId The id of the async task
+	TaskId string `json:"task_id"`
+}
+
+// GenerateAvatarMotionTaskOutputStatus The status of the async task. Possible values are 'IN_QUEUE', 'IN_PROGRESS', 'COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'
+type GenerateAvatarMotionTaskOutputStatus string
+
 // GenerateAvatarStatusApiResponseBody defines model for GenerateAvatarStatusApiResponseBody.
 type GenerateAvatarStatusApiResponseBody struct {
 	Data *GenerateAvatarTaskOutput `json:"data,omitempty"`
@@ -313,6 +370,9 @@ type GenerateTalkingAvatarStatusApiResponseBody struct {
 
 // GenerateTalkingAvatarTaskOutput defines model for GenerateTalkingAvatarTaskOutput.
 type GenerateTalkingAvatarTaskOutput struct {
+	// Error Error message if any
+	Error *string `json:"error,omitempty"`
+
 	// FileUrl The URL of the output MP4 video.
 	FileUrl *string `json:"file_url,omitempty"`
 
@@ -624,6 +684,9 @@ type CloneVoiceAsyncMultipartBody struct {
 	// CleanData Specify whether de-noise processing should be performed. Default is False.
 	CleanData *bool `json:"clean_data,omitempty"`
 
+	// Description Optional description for the new voice profile.
+	Description *string `json:"description,omitempty"`
+
 	// Name The name of the new voice profile to be created. If not provided, a default name will be generated.
 	Name *string `json:"name,omitempty"`
 
@@ -654,6 +717,9 @@ type ConvertSpeechToTextJSONRequestBody = STTApiRequestBody
 
 // ConvertTextToSpeechJSONRequestBody defines body for ConvertTextToSpeech for application/json ContentType.
 type ConvertTextToSpeechJSONRequestBody = TTSApiRequestBody
+
+// GenerateAvatarMotionAsyncJSONRequestBody defines body for GenerateAvatarMotionAsync for application/json ContentType.
+type GenerateAvatarMotionAsyncJSONRequestBody = AsyncGenerateAvatarMotionApiRequestBody
 
 // GenerateTalkingAvatarAsyncJSONRequestBody defines body for GenerateTalkingAvatarAsync for application/json ContentType.
 type GenerateTalkingAvatarAsyncJSONRequestBody = AsyncGenerateTalkingAvatarApiRequestBody
@@ -789,6 +855,14 @@ type ClientInterface interface {
 	ConvertTextToSpeechWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	ConvertTextToSpeech(ctx context.Context, body ConvertTextToSpeechJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GenerateAvatarMotionAsyncWithBody request with any body
+	GenerateAvatarMotionAsyncWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	GenerateAvatarMotionAsync(ctx context.Context, body GenerateAvatarMotionAsyncJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetAvatarMotionGenerationStatus request
+	GetAvatarMotionGenerationStatus(ctx context.Context, taskId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GenerateTalkingAvatarAsyncWithBody request with any body
 	GenerateTalkingAvatarAsyncWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1059,6 +1133,42 @@ func (c *Client) ConvertTextToSpeechWithBody(ctx context.Context, contentType st
 
 func (c *Client) ConvertTextToSpeech(ctx context.Context, body ConvertTextToSpeechJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewConvertTextToSpeechRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GenerateAvatarMotionAsyncWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGenerateAvatarMotionAsyncRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GenerateAvatarMotionAsync(ctx context.Context, body GenerateAvatarMotionAsyncJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGenerateAvatarMotionAsyncRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAvatarMotionGenerationStatus(ctx context.Context, taskId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAvatarMotionGenerationStatusRequest(c.Server, taskId)
 	if err != nil {
 		return nil, err
 	}
@@ -1681,6 +1791,80 @@ func NewConvertTextToSpeechRequestWithBody(server string, contentType string, bo
 	return req, nil
 }
 
+// NewGenerateAvatarMotionAsyncRequest calls the generic GenerateAvatarMotionAsync builder with application/json body
+func NewGenerateAvatarMotionAsyncRequest(server string, body GenerateAvatarMotionAsyncJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewGenerateAvatarMotionAsyncRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewGenerateAvatarMotionAsyncRequestWithBody generates requests for GenerateAvatarMotionAsync with any type of body
+func NewGenerateAvatarMotionAsyncRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/video/async_generate_avatar_motion")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetAvatarMotionGenerationStatusRequest generates requests for GetAvatarMotionGenerationStatus
+func NewGetAvatarMotionGenerationStatusRequest(server string, taskId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "task_id", runtime.ParamLocationPath, taskId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/video/async_generate_avatar_motion/%s/status", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGenerateTalkingAvatarAsyncRequest calls the generic GenerateTalkingAvatarAsync builder with application/json body
 func NewGenerateTalkingAvatarAsyncRequest(server string, body GenerateTalkingAvatarAsyncJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -2039,6 +2223,14 @@ type ClientWithResponsesInterface interface {
 
 	ConvertTextToSpeechWithResponse(ctx context.Context, body ConvertTextToSpeechJSONRequestBody, reqEditors ...RequestEditorFn) (*ConvertTextToSpeechResponse, error)
 
+	// GenerateAvatarMotionAsyncWithBodyWithResponse request with any body
+	GenerateAvatarMotionAsyncWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GenerateAvatarMotionAsyncResponse, error)
+
+	GenerateAvatarMotionAsyncWithResponse(ctx context.Context, body GenerateAvatarMotionAsyncJSONRequestBody, reqEditors ...RequestEditorFn) (*GenerateAvatarMotionAsyncResponse, error)
+
+	// GetAvatarMotionGenerationStatusWithResponse request
+	GetAvatarMotionGenerationStatusWithResponse(ctx context.Context, taskId string, reqEditors ...RequestEditorFn) (*GetAvatarMotionGenerationStatusResponse, error)
+
 	// GenerateTalkingAvatarAsyncWithBodyWithResponse request with any body
 	GenerateTalkingAvatarAsyncWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GenerateTalkingAvatarAsyncResponse, error)
 
@@ -2381,6 +2573,52 @@ func (r ConvertTextToSpeechResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ConvertTextToSpeechResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GenerateAvatarMotionAsyncResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *AsyncGenerateAvatarMotionApiResponseBody
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r GenerateAvatarMotionAsyncResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GenerateAvatarMotionAsyncResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetAvatarMotionGenerationStatusResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *GenerateAvatarMotionStatusApiResponseBody
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAvatarMotionGenerationStatusResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAvatarMotionGenerationStatusResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2751,6 +2989,32 @@ func (c *ClientWithResponses) ConvertTextToSpeechWithResponse(ctx context.Contex
 		return nil, err
 	}
 	return ParseConvertTextToSpeechResponse(rsp)
+}
+
+// GenerateAvatarMotionAsyncWithBodyWithResponse request with arbitrary body returning *GenerateAvatarMotionAsyncResponse
+func (c *ClientWithResponses) GenerateAvatarMotionAsyncWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GenerateAvatarMotionAsyncResponse, error) {
+	rsp, err := c.GenerateAvatarMotionAsyncWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGenerateAvatarMotionAsyncResponse(rsp)
+}
+
+func (c *ClientWithResponses) GenerateAvatarMotionAsyncWithResponse(ctx context.Context, body GenerateAvatarMotionAsyncJSONRequestBody, reqEditors ...RequestEditorFn) (*GenerateAvatarMotionAsyncResponse, error) {
+	rsp, err := c.GenerateAvatarMotionAsync(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGenerateAvatarMotionAsyncResponse(rsp)
+}
+
+// GetAvatarMotionGenerationStatusWithResponse request returning *GetAvatarMotionGenerationStatusResponse
+func (c *ClientWithResponses) GetAvatarMotionGenerationStatusWithResponse(ctx context.Context, taskId string, reqEditors ...RequestEditorFn) (*GetAvatarMotionGenerationStatusResponse, error) {
+	rsp, err := c.GetAvatarMotionGenerationStatus(ctx, taskId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAvatarMotionGenerationStatusResponse(rsp)
 }
 
 // GenerateTalkingAvatarAsyncWithBodyWithResponse request with arbitrary body returning *GenerateTalkingAvatarAsyncResponse
@@ -3271,6 +3535,72 @@ func ParseConvertTextToSpeechResponse(rsp *http.Response) (*ConvertTextToSpeechR
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest TTSApiResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGenerateAvatarMotionAsyncResponse parses an HTTP response from a GenerateAvatarMotionAsyncWithResponse call
+func ParseGenerateAvatarMotionAsyncResponse(rsp *http.Response) (*GenerateAvatarMotionAsyncResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GenerateAvatarMotionAsyncResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AsyncGenerateAvatarMotionApiResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAvatarMotionGenerationStatusResponse parses an HTTP response from a GetAvatarMotionGenerationStatusWithResponse call
+func ParseGetAvatarMotionGenerationStatusResponse(rsp *http.Response) (*GetAvatarMotionGenerationStatusResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAvatarMotionGenerationStatusResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GenerateAvatarMotionStatusApiResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -555,7 +555,7 @@ func (c *Client) DeleteVoiceProfile(ctx context.Context, profileID string) (*api
 	return resp, nil
 }
 
-func (c *Client) CloneVoice(ctx context.Context, name string, audioDir string, annotationFile string, cleanData bool) (*api.AsyncFinetuningApiResponseBody, error) {
+func (c *Client) CloneVoice(ctx context.Context, name string, audioDir string, annotationFile string, cleanData bool, description string) (*api.AsyncFinetuningApiResponseBody, error) {
 	// Create multipart form data
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -572,6 +572,13 @@ func (c *Client) CloneVoice(ctx context.Context, name string, audioDir string, a
 	}
 	if err := writer.WriteField("clean_data", cleanDataStr); err != nil {
 		return nil, fmt.Errorf("failed to write clean_data field: %w", err)
+	}
+
+	// Add description field if provided
+	if description != "" {
+		if err := writer.WriteField("description", description); err != nil {
+			return nil, fmt.Errorf("failed to write description field: %w", err)
+		}
 	}
 
 	// Add annotation file

--- a/pkg/cmd/image/image.go
+++ b/pkg/cmd/image/image.go
@@ -132,7 +132,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 			currentStatus = string(statusResp.Data.Status)
 
-			if statusResp.Data.Status == api.COMPLETED {
+			if statusResp.Data.Status == api.GenerateTaskOutputStatusCOMPLETED {
 				fmt.Print(clearLine) // Clear the spinner line
 				fmt.Printf("✅ Generation completed!\n")
 
@@ -187,9 +187,9 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 				}
 
 				return nil
-			} else if statusResp.Data.Status == api.FAILED ||
-				statusResp.Data.Status == api.CANCELED ||
-				statusResp.Data.Status == api.TIMEDOUT {
+			} else if statusResp.Data.Status == api.GenerateTaskOutputStatusFAILED ||
+				statusResp.Data.Status == api.GenerateTaskOutputStatusCANCELED ||
+				statusResp.Data.Status == api.GenerateTaskOutputStatusTIMEDOUT {
 				fmt.Print(clearLine) // Clear the spinner line
 				return fmt.Errorf("image generation failed with status: %s", statusResp.Data.Status)
 			}

--- a/spec/openapi-3.0.yaml
+++ b/spec/openapi-3.0.yaml
@@ -140,6 +140,7 @@ components:
         prompt:
           description: The prompt for the avatar generation.
           example: A realistic photo of an Asian girl with long black hair, round-shaped eyes, wearing pink t-shirt, standing in front of a solid background.
+          maxLength: 250
           type: string
         seed:
           description: Random seed for the generation, if not provided a random seed will be used
@@ -159,6 +160,43 @@ components:
         data:
           $ref: "#/components/schemas/AsyncTaskStatus"
           description: The task status for the avatar generation task
+      type: object
+    AsyncGenerateAvatarMotionApiRequestBody:
+      additionalProperties: false
+      properties:
+        audio:
+          description: The base64 encoded audio file to use as the avatar's speech.
+          example: UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQ==
+          type: string
+        image:
+          description: The base64 encoded image to use as the starting frame, which should clearly showing the avatar's face.
+          example: iVBORw0KGgoAAAANSUhEUgAA...
+          type: string
+        negative_prompt:
+          description: The negative prompt to guide the avatar motion generation.
+          example: ""
+          maxLength: 512
+          type: string
+        positive_prompt:
+          description: The positive prompt to guide the avatar motion generation.
+          example: A happy young man laughing.
+          maxLength: 512
+          type: string
+        webhook:
+          $ref: "#/components/schemas/Webhook"
+          description: The webhook url to notify when the task is completed
+      required:
+        - image
+        - audio
+        - positive_prompt
+        - negative_prompt
+      type: object
+    AsyncGenerateAvatarMotionApiResponseBody:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: "#/components/schemas/AsyncTaskStatus"
+          description: The task status for the avatar motion generation task
       type: object
     AsyncGenerateAvatarWebhookRequestBody:
       additionalProperties: true
@@ -531,6 +569,109 @@ components:
         - task_id
         - status
       type: object
+    GenerateAvatarMotionOutputInternal:
+      additionalProperties: false
+      properties:
+        engine_processing_time:
+          description: Model inference time in seconds.
+          format: float
+          type: number
+        error:
+          description: Error message if any
+          type: string
+        output_duration:
+          description: The duration of the output video in seconds.
+          example: 5
+          format: double
+          type: number
+        processing_info:
+          description: Additional info about the processing.
+          type: string
+        request_id:
+          description: The id of the request
+          type: string
+        result_b64_str:
+          description: The base64-encoded MP4 video output. Only available when the result_type is 'b64_str'.
+          type: string
+        result_s3_info:
+          $ref: "#/components/schemas/RemoteFile"
+          description: S3 information for the output video. Only available when the result_type is 's3_file'.
+        total_processing_time:
+          description: Total processing time in seconds.
+          format: float
+          type: number
+      required:
+        - request_id
+      type: object
+    GenerateAvatarMotionStatusApiResponseBody:
+      additionalProperties: false
+      properties:
+        data:
+          $ref: "#/components/schemas/GenerateAvatarMotionTaskOutput"
+          description: The avatar motion generation task output
+      type: object
+    GenerateAvatarMotionTaskOutput:
+      additionalProperties: false
+      properties:
+        error:
+          description: Error message if any
+          type: string
+        file_url:
+          description: The URL of the output MP4 video.
+          type: string
+        output_duration:
+          description: The duration of the output video in seconds.
+          example: 5
+          format: double
+          type: number
+        status:
+          description: The status of the async task. Possible values are 'IN_QUEUE', 'IN_PROGRESS', 'COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'
+          enum:
+            - IN_QUEUE
+            - IN_PROGRESS
+            - COMPLETED
+            - FAILED
+            - CANCELED
+            - TIMED_OUT
+          example: IN_PROGRESS
+          type: string
+        task_id:
+          description: The id of the async task
+          example: xdac2o3c
+          type: string
+      required:
+        - task_id
+        - status
+      type: object
+    GenerateAvatarMotionWebhookRequestBody:
+      additionalProperties: true
+      properties:
+        delayTime:
+          description: The time taken to process the request
+          format: int64
+          type: integer
+        error:
+          description: The error message if any
+          type: string
+        executionTime:
+          description: The time taken to process the request
+          format: int64
+          type: integer
+        id:
+          description: The id of the request
+          type: string
+        output:
+          $ref: "#/components/schemas/GenerateAvatarMotionOutputInternal"
+          description: The output of the request
+        status:
+          description: The status of the request. Possible values are 'IN_QUEUE', 'IN_PROGRESS', 'COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'
+          type: string
+      required:
+        - id
+        - delayTime
+        - executionTime
+        - status
+      type: object
     GenerateAvatarOutput:
       additionalProperties: false
       properties:
@@ -612,6 +753,9 @@ components:
     GenerateTalkingAvatarTaskOutput:
       additionalProperties: false
       properties:
+        error:
+          description: Error message if any
+          type: string
         file_url:
           description: The URL of the output MP4 video.
           type: string
@@ -1146,6 +1290,7 @@ components:
         instruction:
           description: The instruction prompt for the avatar in the session
           example: You are a helpful assistant.
+          maxLength: 12000
           type: string
         llm_model:
           description: The LLM model to be used for generating avatar's response
@@ -1752,6 +1897,64 @@ paths:
       summary: Text to speech
       tags:
         - Speech
+  /v1/video/async_generate_avatar_motion:
+    post:
+      description: Create a avatar motion video generation task. This is an async operation.
+      operationId: GenerateAvatarMotionAsync
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AsyncGenerateAvatarMotionApiRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AsyncGenerateAvatarMotionApiResponseBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - BearerAuth: []
+      summary: Generate a avatar motion video (async)
+      tags:
+        - Video
+  /v1/video/async_generate_avatar_motion/{task_id}/status:
+    get:
+      description: Get the status of a avatar motion video generation task.
+      operationId: GetAvatarMotionGenerationStatus
+      parameters:
+        - description: The task ID of the avatar motion video generation task
+          in: path
+          name: task_id
+          required: true
+          schema:
+            description: The task ID of the avatar motion video generation task
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenerateAvatarMotionStatusApiResponseBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      security:
+        - BearerAuth: []
+      summary: Get avatar motion task status
+      tags:
+        - Video
   /v1/video/async_generate_talking_avatar:
     post:
       description: Create a talking avatar video generation task. This is an async operation.
@@ -1824,6 +2027,8 @@ paths:
                 contentType: audio/wav
               clean_data:
                 contentType: text/plain
+              description:
+                contentType: text/plain
               name:
                 contentType: text/plain
               webhook:
@@ -1850,6 +2055,11 @@ paths:
                   default: false
                   description: Specify whether de-noise processing should be performed. Default is False.
                   type: boolean
+                description:
+                  description: Optional description for the new voice profile.
+                  example: Sweet British woman voice.
+                  maxLength: 512
+                  type: string
                 name:
                   description: The name of the new voice profile to be created. If not provided, a default name will be generated.
                   example: My Custom Voice


### PR DESCRIPTION
- Update cli with the latest api changes:
    - Interactive instructions now allows up to 12k characters "~3000 tokens"
    - Add `description` field to be provided when performing voice cloning.
