### PR TITLE
feat: show avatar supported models

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,5 +63,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/mirako-ai/mirako-go => ../mirako-go

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/fatih/color v1.18.0
-	github.com/mirako-ai/mirako-go v1.2.0
+	github.com/mirako-ai/mirako-go v1.2.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
@@ -63,3 +63,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/mirako-ai/mirako-go => ../mirako-go

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/mirako-ai/mirako-go v1.2.0 h1:nsMfC5uVSGtut0LemnVN5PHeeqEaL315aTF+nQ9V0fw=
-github.com/mirako-ai/mirako-go v1.2.0/go.mod h1:CHrOBUwKFlRSMiFEIiBFyDhiGFq1ZH9m1sre7OX8gT4=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mirako-ai/mirako-go v1.2.1 h1:6w4kmLH1qVJchN4mFcwk2ptk5/i1O/sc7gKuKTNW/2M=
+github.com/mirako-ai/mirako-go v1.2.1/go.mod h1:CHrOBUwKFlRSMiFEIiBFyDhiGFq1ZH9m1sre7OX8gT4=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/pkg/cmd/avatar/avatar.go
+++ b/pkg/cmd/avatar/avatar.go
@@ -89,6 +89,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			avatar.Name,
 			avatar.Id,
 			avatar.Status,
+			formatSupportedInteractiveModels(avatar.SupportedInteractiveModels),
 			ui.FormatTimestamp(avatar.CreatedAt),
 		})
 	}
@@ -133,6 +134,7 @@ func runView(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Status: %s\n", resp.Data.Status)
 	fmt.Printf("Created: %s\n", resp.Data.CreatedAt.Local().Format("2006-01-02 15:04"))
 	fmt.Printf("User ID: %s\n", resp.Data.UserId)
+	fmt.Printf("Supported Models: %s\n", formatSupportedInteractiveModels(resp.Data.SupportedInteractiveModels))
 
 	if resp.Data.Themes != nil && len(*resp.Data.Themes) > 0 {
 		fmt.Println("\nThemes:")
@@ -148,6 +150,14 @@ func runView(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func formatSupportedInteractiveModels(models *[]string) string {
+	if models == nil || len(*models) == 0 {
+		return "-"
+	}
+
+	return strings.Join(*models, ", ")
 }
 
 func newGenerateCmd() *cobra.Command {

--- a/pkg/cmd/avatar/avatar_test.go
+++ b/pkg/cmd/avatar/avatar_test.go
@@ -1,0 +1,34 @@
+package avatar
+
+import "testing"
+
+func TestFormatSupportedInteractiveModels(t *testing.T) {
+	tests := []struct {
+		name   string
+		models *[]string
+		want   string
+	}{
+		{
+			name: "nil models",
+			want: "-",
+		},
+		{
+			name:   "empty models",
+			models: &[]string{},
+			want:   "-",
+		},
+		{
+			name:   "populated models",
+			models: &[]string{"metis-2.5", "metis-3.0"},
+			want:   "metis-2.5, metis-3.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatSupportedInteractiveModels(tt.models); got != tt.want {
+				t.Fatalf("formatSupportedInteractiveModels() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -148,7 +148,7 @@ func FormatDuration(d time.Duration) string {
 // NewAvatarTable creates a table for displaying avatar information
 func NewAvatarTable(output io.Writer) *TableWriter {
 	t := NewTableWriter(output)
-	t.SetHeader([]string{"NAME", "ID", "STATUS", "CREATED"})
+	t.SetHeader([]string{"NAME", "ID", "STATUS", "MODELS", "CREATED"})
 	return t
 }
 

--- a/spec/openapi-3.0.yaml
+++ b/spec/openapi-3.0.yaml
@@ -5,11 +5,13 @@ components:
       properties:
         auth_token_type:
           description: Type of the authentication token used for this API user. Possible values are 'api_token', 'jwt_token'
-          example: api_token
+          examples:
+            - api_token
           type: string
         created_at:
           description: Creation timestamp of the API token
-          example: "2023-10-01T12:00:00Z"
+          examples:
+            - "2023-10-01T12:00:00Z"
           format: date-time
           type: string
         events:
@@ -18,27 +20,33 @@ components:
           type: object
         hint:
           description: Hint for the API token, used for displaying in the UI
-          example: mi-AbCdE
+          examples:
+            - mi-AbCdE
           type: string
         is_delinquent:
           description: Indicates if the API user is delinquent, e.g., negative credits, unpaid bills
-          example: false
+          examples:
+            - false
           type: boolean
         label:
           description: Label for the API token, used for describing the purpose of the token
-          example: My API Token
+          examples:
+            - My API Token
           type: string
         token_id:
           description: Unique identifier for the API token. Empty if user authenticated by jwt session.
-          example: YjR7k2L9xWpZcV3oA1sF
+          examples:
+            - YjR7k2L9xWpZcV3oA1sF
           type: string
         type:
           description: Type of the API user. Default to 'user'
-          example: user
+          examples:
+            - user
           type: string
         user_id:
           description: User ID of the API token owner
-          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          examples:
+            - f47ac10b-58cc-4372-a567-0e02b2c3d479
           type: string
       required:
         - hint
@@ -55,11 +63,13 @@ components:
       properties:
         is_delinquent:
           description: Indicates if the API user is delinquent, e.g., negative credits, unpaid bills
-          example: false
+          examples:
+            - false
           type: boolean
         user_id:
           description: User ID of the API user
-          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          examples:
+            - f47ac10b-58cc-4372-a567-0e02b2c3d479
           type: string
       required:
         - user_id
@@ -69,13 +79,15 @@ components:
       additionalProperties: false
       properties:
         image:
+          contentEncoding: base64
           description: The base64 encoded image to build the avatar from
-          example: iVBORw0KGgoAAAANSUhEUgAA...
-          format: base64
+          examples:
+            - iVBORw0KGgoAAAANSUhEUgAA...
           type: string
         name:
           description: The name of the avatar
-          example: Avatar Name
+          examples:
+            - Avatar Name
           type: string
       required:
         - name
@@ -93,7 +105,8 @@ components:
       properties:
         avatar_id:
           description: The ID of the created avatar
-          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+          examples:
+            - a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
       required:
         - avatar_id
@@ -139,12 +152,14 @@ components:
       properties:
         prompt:
           description: The prompt for the avatar generation.
-          example: A realistic photo of an Asian girl with long black hair, round-shaped eyes, wearing pink t-shirt, standing in front of a solid background.
+          examples:
+            - A realistic photo of an Asian girl with long black hair, round-shaped eyes, wearing pink t-shirt, standing in front of a solid background.
           maxLength: 1000
           type: string
         seed:
           description: Random seed for the generation, if not provided a random seed will be used
-          example: 1234567890
+          examples:
+            - 1234567890
           format: int64
           minimum: 0
           type: integer
@@ -166,20 +181,24 @@ components:
       properties:
         audio:
           description: The base64 encoded audio file to use as the avatar's speech.
-          example: UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQ==
+          examples:
+            - UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQ==
           type: string
         image:
           description: The base64 encoded image to use as the starting frame, which should clearly showing the avatar's face.
-          example: iVBORw0KGgoAAAANSUhEUgAA...
+          examples:
+            - iVBORw0KGgoAAAANSUhEUgAA...
           type: string
         negative_prompt:
           description: The negative prompt to guide the avatar motion generation.
-          example: ""
+          examples:
+            - ""
           maxLength: 512
           type: string
         positive_prompt:
           description: The positive prompt to guide the avatar motion generation.
-          example: A happy young man laughing.
+          examples:
+            - A happy young man laughing.
           maxLength: 512
           type: string
         webhook:
@@ -240,22 +259,26 @@ components:
             - "2:3"
             - "3:4"
             - "9:16"
-          example: "16:9"
+          examples:
+            - "16:9"
           type: string
         images:
           description: Optional. List of labeld images in base64 format for text-image-to-image generation. Maximum 5 images can be provided as input.
           items:
             $ref: "#/components/schemas/LabeledImage"
           maxItems: 5
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
         prompt:
           description: The prompt for the image generation. Include in the prompt the Avatar Id (uuid) to generate image of the avatar.
-          example: A girl sitting in a cafe smiling, wide-shot, angled view.
+          examples:
+            - A girl sitting in a cafe smiling, wide-shot, angled view.
           type: string
         seed:
           description: Seed for the generation, if not provided a random seed will be used
-          example: 1234567890
+          examples:
+            - 1234567890
           format: int32
           type: integer
         webhook:
@@ -277,11 +300,13 @@ components:
       properties:
         audio:
           description: The base64 encoded audio file to use as the avatar's speech.
-          example: UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQ==
+          examples:
+            - UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQ==
           type: string
         image:
           description: The base64 encoded image to use as the avatar's face.
-          example: iVBORw0KGgoAAAANSUhEUgAA...
+          examples:
+            - iVBORw0KGgoAAAANSUhEUgAA...
           type: string
         webhook:
           $ref: "#/components/schemas/Webhook"
@@ -309,11 +334,13 @@ components:
             - FAILED
             - CANCELED
             - TIMED_OUT
-          example: IN_PROGRESS
+          examples:
+            - IN_PROGRESS
           type: string
         task_id:
           description: The id of the async task
-          example: xdac2o3c
+          examples:
+            - xdac2o3c
           type: string
       required:
         - task_id
@@ -324,16 +351,19 @@ components:
       properties:
         created_at:
           description: Creation timestamp of the avatar
-          example: "2023-10-01T12:00:00Z"
+          examples:
+            - "2023-10-01T12:00:00Z"
           format: date-time
           type: string
         id:
           description: Unique identifier for the avatar
-          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+          examples:
+            - a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
         name:
           description: Name of the avatar
-          example: My Avatar
+          examples:
+            - My Avatar
           type: string
         status:
           description: Status of the avatar, either 'PENDING', 'BUILDING', 'READY' or 'ERROR'
@@ -342,17 +372,27 @@ components:
             - BUILDING
             - READY
             - ERROR
-          example: READY
+          examples:
+            - READY
           type: string
+        supported_interactive_models:
+          description: Interactive models supported by this avatar
+          items:
+            type: string
+          type:
+            - array
+            - "null"
         themes:
           description: Avatar themes are the different appearances of the avatar, each with its own key image and live video.
           items:
             $ref: "#/components/schemas/PresignedAvatarTheme"
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
         user_id:
           description: User ID of the owner of this avatar
-          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          examples:
+            - f47ac10b-58cc-4372-a567-0e02b2c3d479
           type: string
       required:
         - id
@@ -360,6 +400,7 @@ components:
         - name
         - created_at
         - status
+        - supported_interactive_models
         - themes
       type: object
     CreateApiTokenOutput:
@@ -367,11 +408,13 @@ components:
       properties:
         auth_token_type:
           description: Type of the authentication token used for this API user. Possible values are 'api_token', 'jwt_token'
-          example: api_token
+          examples:
+            - api_token
           type: string
         created_at:
           description: Creation timestamp of the API token
-          example: "2023-10-01T12:00:00Z"
+          examples:
+            - "2023-10-01T12:00:00Z"
           format: date-time
           type: string
         events:
@@ -380,29 +423,35 @@ components:
           type: object
         hint:
           description: Hint for the API token, used for displaying in the UI
-          example: mi-AbCdE
+          examples:
+            - mi-AbCdE
           type: string
         is_delinquent:
           description: Indicates if the API user is delinquent, e.g., negative credits, unpaid bills
-          example: false
+          examples:
+            - false
           type: boolean
         label:
           description: Label for the API token, used for describing the purpose of the token
-          example: My API Token
+          examples:
+            - My API Token
           type: string
         token:
           type: string
         token_id:
           description: Unique identifier for the API token. Empty if user authenticated by jwt session.
-          example: YjR7k2L9xWpZcV3oA1sF
+          examples:
+            - YjR7k2L9xWpZcV3oA1sF
           type: string
         type:
           description: Type of the API user. Default to 'user'
-          example: user
+          examples:
+            - user
           type: string
         user_id:
           description: User ID of the API token owner
-          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          examples:
+            - f47ac10b-58cc-4372-a567-0e02b2c3d479
           type: string
       required:
         - token
@@ -420,7 +469,8 @@ components:
       properties:
         label:
           description: Label for the API token
-          example: My API Token
+          examples:
+            - My API Token
           maxLength: 100
           type: string
       required:
@@ -473,32 +523,38 @@ components:
       properties:
         detail:
           description: A human-readable explanation specific to this occurrence of the problem.
-          example: Property foo is required but is missing.
+          examples:
+            - Property foo is required but is missing.
           type: string
         errors:
           description: Optional list of individual error details
           items:
             $ref: "#/components/schemas/ErrorDetail"
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
         instance:
           description: A URI reference that identifies the specific occurrence of the problem.
-          example: https://example.com/error-log/abc123
+          examples:
+            - https://example.com/error-log/abc123
           format: uri
           type: string
         status:
           description: HTTP status code
-          example: 400
+          examples:
+            - 400
           format: int64
           type: integer
         title:
           description: A short, human-readable summary of the problem type. This value should not change between occurrences of the error.
-          example: Bad Request
+          examples:
+            - Bad Request
           type: string
         type:
           default: about:blank
           description: A URI reference to human-readable documentation for the error.
-          example: https://example.com/errors/example
+          examples:
+            - https://example.com/errors/example
           format: uri
           type: string
       type: object
@@ -565,11 +621,13 @@ components:
             - FAILED
             - CANCELED
             - TIMED_OUT
-          example: IN_PROGRESS
+          examples:
+            - IN_PROGRESS
           type: string
         task_id:
           description: The id of the async task
-          example: xdac2o3c
+          examples:
+            - xdac2o3c
           type: string
       required:
         - task_id
@@ -587,7 +645,8 @@ components:
           type: string
         output_duration:
           description: The duration of the output video in seconds.
-          example: 5
+          examples:
+            - 5
           format: double
           type: number
         processing_info:
@@ -627,7 +686,8 @@ components:
           type: string
         output_duration:
           description: The duration of the output video in seconds.
-          example: 5
+          examples:
+            - 5
           format: double
           type: number
         status:
@@ -639,11 +699,13 @@ components:
             - FAILED
             - CANCELED
             - TIMED_OUT
-          example: IN_PROGRESS
+          examples:
+            - IN_PROGRESS
           type: string
         task_id:
           description: The id of the async task
-          example: xdac2o3c
+          examples:
+            - xdac2o3c
           type: string
       required:
         - task_id
@@ -707,11 +769,13 @@ components:
             - FAILED
             - CANCELED
             - TIMED_OUT
-          example: IN_PROGRESS
+          examples:
+            - IN_PROGRESS
           type: string
         task_id:
           description: The id of the async task
-          example: xdac2o3c
+          examples:
+            - xdac2o3c
           type: string
       required:
         - task_id
@@ -730,22 +794,26 @@ components:
             - "2:3"
             - "3:4"
             - "9:16"
-          example: "16:9"
+          examples:
+            - "16:9"
           type: string
         images:
           description: Optional. List of labeld images in base64 format for text-image-to-image generation. Maximum 5 images can be provided as input.
           items:
             $ref: "#/components/schemas/LabeledImage"
           maxItems: 5
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
         prompt:
           description: The prompt for the image generation. Include in the prompt the Avatar Id (uuid) to generate image of the avatar.
-          example: A girl sitting in a cafe smiling, wide-shot, angled view.
+          examples:
+            - A girl sitting in a cafe smiling, wide-shot, angled view.
           type: string
         seed:
           description: Seed for the generation, if not provided a random seed will be used
-          example: 1234567890
+          examples:
+            - 1234567890
           format: int32
           type: integer
       required:
@@ -788,7 +856,8 @@ components:
           type: number
         output_duration:
           description: The duration of the output video in seconds.
-          example: 5
+          examples:
+            - 5
           format: double
           type: number
         s3_info:
@@ -816,7 +885,8 @@ components:
           type: string
         output_duration:
           description: The duration of the output video in seconds.
-          example: 5
+          examples:
+            - 5
           format: double
           type: number
         status:
@@ -828,11 +898,13 @@ components:
             - FAILED
             - CANCELED
             - TIMED_OUT
-          example: IN_PROGRESS
+          examples:
+            - IN_PROGRESS
           type: string
         task_id:
           description: The id of the async task
-          example: xdac2o3c
+          examples:
+            - xdac2o3c
           type: string
       required:
         - task_id
@@ -882,11 +954,13 @@ components:
             - FAILED
             - CANCELED
             - TIMED_OUT
-          example: IN_PROGRESS
+          examples:
+            - IN_PROGRESS
           type: string
         task_id:
           description: The id of the async task
-          example: xdac2o3c
+          examples:
+            - xdac2o3c
           type: string
       required:
         - task_id
@@ -926,8 +1000,9 @@ components:
           description: List of premade voice profiles
           items:
             $ref: "#/components/schemas/PresignedVoiceProfile"
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       required:
         - data
       type: object
@@ -952,8 +1027,9 @@ components:
           description: List of avatars for the user
           items:
             $ref: "#/components/schemas/AvatarResponse"
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       required:
         - data
       type: object
@@ -973,8 +1049,9 @@ components:
           description: List of user custom voice profiles
           items:
             $ref: "#/components/schemas/PresignedVoiceProfile"
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       required:
         - data
       type: object
@@ -983,11 +1060,13 @@ components:
       properties:
         data:
           description: The image in data-url base64 format. Currently support 'image/jpeg' and 'image/png' format.
-          example: data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD...
+          examples:
+            - data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD...
           type: string
         label:
           description: The label of the image. Used to identify and refer the image in the given prompt.
-          example: Product
+          examples:
+            - Product
           type: string
       required:
         - data
@@ -997,7 +1076,8 @@ components:
       properties:
         model:
           description: The interactive model version to be launched.
-          example: metis-2.5
+          examples:
+            - metis-2.5
           type: string
         opts:
           additionalProperties: {}
@@ -1005,7 +1085,8 @@ components:
           type: object
         session_group:
           description: The session group name for the instance. Default session group will be used if it left unspecfied or empty.
-          example: default
+          examples:
+            - default
           type: string
       required:
         - model
@@ -1024,8 +1105,9 @@ components:
           description: List of API tokens for the user
           items:
             $ref: "#/components/schemas/ApiTokenRecord"
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       required:
         - data
       type: object
@@ -1036,8 +1118,9 @@ components:
           description: List of active interactive sessions
           items:
             $ref: "#/components/schemas/MetisSession"
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       type: object
     Machine:
       additionalProperties: false
@@ -1136,6 +1219,8 @@ components:
     PresignedAvatarSystemProfile:
       additionalProperties: false
       properties:
+        expression_video:
+          $ref: "#/components/schemas/PresignedExpressionVideo"
         id:
           type: string
         image:
@@ -1143,75 +1228,106 @@ components:
         liveportrait:
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
         name:
           type: string
+        supported_interactive_models:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
       required:
         - id
         - name
+        - supported_interactive_models
       type: object
     PresignedAvatarTheme:
       additionalProperties: false
       properties:
         key_image:
           description: URL of the key portrait image of the avatar in this theme.
-          example: https://example.com/image.png
+          examples:
+            - https://example.com/image.png
           type: string
         live_video:
           description: URL of the live video for the avatar in this theme.
-          example: https://example.com/live.mp4
+          examples:
+            - https://example.com/live.mp4
           type: string
         name:
           description: Name of the avatar theme
-          example: Default
+          examples:
+            - Default
           type: string
       required:
         - name
+      type: object
+    PresignedExpressionVideo:
+      additionalProperties: false
+      properties:
+        base:
+          type: string
+        signature:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
       type: object
     PresignedVoiceProfile:
       additionalProperties: false
       properties:
         created_at:
           description: The creation date of the voice profile.
-          example: "2023-10-01T12:00:00Z"
+          examples:
+            - "2023-10-01T12:00:00Z"
           format: date-time
           type: string
         description:
           description: The description of the voice profile.
-          example: A friendly and professional voice for customer support.
+          examples:
+            - A friendly and professional voice for customer support.
           type: string
         id:
           description: The unique identifier for the voice profile.
           type: string
         is_premade:
           description: Whether the voice profile is a default premade profile.
-          example: true
+          examples:
+            - true
           type: boolean
         languages:
           description: The languages supported by the voice profile.
-          example:
-            - en
-            - yue
+          examples:
+            - - en
+              - yue
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
         name:
           description: The name of the voice profile.
-          example: Mira Korner
+          examples:
+            - Mira Korner
           type: string
         sample_clip:
           description: The URL of a sample audio clip for the voice profile.
-          example: https://example.com/sample.mp3
+          examples:
+            - https://example.com/sample.mp3
           type: string
         status:
           description: The status of the voice profile.
-          example: READY
+          examples:
+            - READY
           type: string
         user_id:
           description: The user ID of the owner associated with the voice profile.
-          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          examples:
+            - f47ac10b-58cc-4372-a567-0e02b2c3d479
           type: string
       required:
         - id
@@ -1221,32 +1337,37 @@ components:
       properties:
         created_at:
           description: The creation date of the voice profile.
-          example: "2023-10-01T12:00:00Z"
+          examples:
+            - "2023-10-01T12:00:00Z"
           format: date-time
           type: string
         description:
           description: The description of the voice profile.
-          example: A friendly and professional voice for customer support.
+          examples:
+            - A friendly and professional voice for customer support.
           type: string
         id:
           description: The unique identifier for the voice profile.
           type: string
         is_premade:
           description: Whether the voice profile is a default premade profile.
-          example: true
+          examples:
+            - true
           type: boolean
         languages:
           description: The languages supported by the voice profile.
-          example:
-            - en
-            - yue
+          examples:
+            - - en
+              - yue
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
         name:
           description: The name of the voice profile.
-          example: Mira Korner
+          examples:
+            - Mira Korner
           type: string
         params:
           additionalProperties: {}
@@ -1254,18 +1375,21 @@ components:
           type: object
         sample_clip:
           description: The URL of a sample audio clip for the voice profile.
-          example: https://example.com/sample.mp3
+          examples:
+            - https://example.com/sample.mp3
           type: string
         service_name:
           description: The name of the voice service used for this profile.
           type: string
         status:
           description: The status of the voice profile.
-          example: READY
+          examples:
+            - READY
           type: string
         user_id:
           description: The user ID of the owner associated with the voice profile.
-          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+          examples:
+            - f47ac10b-58cc-4372-a567-0e02b2c3d479
           type: string
       required:
         - id
@@ -1300,9 +1424,10 @@ components:
       additionalProperties: false
       properties:
         audio:
+          contentEncoding: base64
           description: Base64 encoded audio data
-          example: UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQ==
-          format: base64
+          examples:
+            - UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQ==
           type: string
       required:
         - audio
@@ -1319,26 +1444,30 @@ components:
       properties:
         id:
           description: The unique request ID
-          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+          examples:
+            - a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
         input_duration:
           description: The duration of the input audio in seconds.
-          example: 5
+          examples:
+            - 5
           format: double
           type: number
         text:
           description: The transcribed text
-          example: Simplicity is the ultimate sophistication.
+          examples:
+            - Simplicity is the ultimate sophistication.
           type: string
         transcription:
           description: The transcription of the audio
-          example:
-            - end: 3
-              start: 0
-              text: Simplicity is the ultimate sophistication.
+          examples:
+            - - end: 3
+                start: 0
+                text: Simplicity is the ultimate sophistication.
           items: {}
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       required:
         - id
         - text
@@ -1349,39 +1478,46 @@ components:
       properties:
         avatar_id:
           description: The avatar id
-          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+          examples:
+            - a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
         idle_timeout:
           description: Idle timeout in mins. The default value is 15 minutes if not specified. Setting it to -1 will disable the idle timeout, making the session never auto-terminate due to inactivity.
-          example: 15
+          examples:
+            - 15
           format: int64
           type: integer
         instruction:
           description: The instruction prompt for the avatar in the session
-          example: You are a helpful assistant.
+          examples:
+            - You are a helpful assistant.
           maxLength: 12000
           type: string
         llm_model:
           description: The LLM model to be used for generating avatar's response
-          example: gemini-2.0-flash
+          examples:
+            - gemini-2.0-flash
           type: string
         model:
           default: metis-2.5
           description: The interactive model version. The default model used is 'metis-2.5'
           enum:
             - metis-2.5
-          example: metis-2.5
+          examples:
+            - metis-2.5
           type: string
         tools:
           description: The tools to be used in the session
           type: string
         use_beta:
           description: Use beta interactive model. Beta model is the latest dev model, which is rapidly changed, may have bugs and not suitable for production. Default is false.
-          example: false
+          examples:
+            - false
           type: boolean
         voice_profile_id:
           description: The voice profile id
-          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+          examples:
+            - a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
       required:
         - avatar_id
@@ -1416,8 +1552,9 @@ components:
           description: The list of stopped session IDs
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       required:
         - stopped_sessions
       type: object
@@ -1428,8 +1565,9 @@ components:
           description: The id of the sessions to be stopped
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       required:
         - session_ids
       type: object
@@ -1449,24 +1587,28 @@ components:
           enum:
             - mandarin
             - yue
-          example: yue
+          examples:
+            - yue
           type: string
         opts:
           $ref: "#/components/schemas/TTSParams"
           description: Optional parameters to control the style of the output audio.
         return_type:
           description: Return type of the audio, either 'b64_audio_str' or 'file_url'.
-          example: b64_audio_str
+          examples:
+            - b64_audio_str
           type: string
         text:
           description: Text to be converted to speech
-          example: Simplicity is the ultimate sophistication.
+          examples:
+            - Simplicity is the ultimate sophistication.
           maxLength: 10000
           minLength: 1
           type: string
         voice_profile_id:
           description: Voice profile ID
-          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+          examples:
+            - a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
       required:
         - text
@@ -1485,24 +1627,29 @@ components:
       properties:
         b64_audio_str:
           description: The PCM s16 audio data encoded as a base64 string. Only available when the return_type is 'b64_audio_str'.
-          example: UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQ==
+          examples:
+            - UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQ==
           type: string
         file_url:
           description: The URL of the audio file. Only available when the return_type is 'file_url'.
-          example: https://mirako.ai/audio/a1b2c3d4-e5f6-7890-1234-567890abcdef.wav
+          examples:
+            - https://mirako.ai/audio/a1b2c3d4-e5f6-7890-1234-567890abcdef.wav
           type: string
         id:
           description: The unique request ID
-          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+          examples:
+            - a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
         output_duration:
           description: The duration of the output audio in seconds.
-          example: 5
+          examples:
+            - 5
           format: double
           type: number
         voice_profile_id:
           description: The voice profile ID used for TTS
-          example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+          examples:
+            - a1b2c3d4-e5f6-7890-1234-567890abcdef
           type: string
       required:
         - id
@@ -1513,14 +1660,16 @@ components:
       properties:
         fragment_interval:
           description: Control the length of pause between sentenses. Default is 0.1.
-          example: 0.1
+          examples:
+            - 0.1
           format: float
           maximum: 1
           minimum: 0
           type: number
         temperature:
           description: The temperature for the TTS model, controls the randomness of the output. Default is 1.0.
-          example: 1
+          examples:
+            - 1
           format: float
           maximum: 1
           minimum: 0
@@ -1533,8 +1682,9 @@ components:
           description: The id of the instances to be terminated
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       required:
         - instance_id
       type: object
@@ -1552,8 +1702,9 @@ components:
           description: The list of terminated instance IDs
           items:
             type: string
-          nullable: true
-          type: array
+          type:
+            - array
+            - "null"
       required:
         - terminated_instances
       type: object
@@ -1562,11 +1713,13 @@ components:
       properties:
         auth_token:
           description: "Auth token used to authenticate the webhook via 'Authorization: Bearer' header"
-          example: secure_token_for_webhook
+          examples:
+            - secure_token_for_webhook
           type: string
         url:
           description: Webhook URL to receive the async task status
-          example: https://my-ai-service.com/webhook
+          examples:
+            - https://my-ai-service.com/webhook
           type: string
       required:
         - url
@@ -1581,7 +1734,7 @@ components:
 info:
   title: Mirako API
   version: 1.0.0
-openapi: 3.0.3
+openapi: 3.1.0
 paths:
   /v1/avatar/async_build:
     post:
@@ -1703,7 +1856,8 @@ paths:
           required: true
           schema:
             description: The avatar id
-            example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+            examples:
+              - a1b2c3d4-e5f6-7890-1234-567890abcdef
             type: string
       responses:
         "204":
@@ -1730,7 +1884,8 @@ paths:
           required: true
           schema:
             description: The avatar id
-            example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+            examples:
+              - a1b2c3d4-e5f6-7890-1234-567890abcdef
             type: string
       responses:
         "200":
@@ -2158,12 +2313,14 @@ paths:
                   type: boolean
                 description:
                   description: Optional description for the new voice profile.
-                  example: Sweet British woman voice.
+                  examples:
+                    - Sweet British woman voice.
                   maxLength: 512
                   type: string
                 name:
                   description: The name of the new voice profile to be created. If not provided, a default name will be generated.
-                  example: My Custom Voice
+                  examples:
+                    - My Custom Voice
                   maxLength: 64
                   minLength: 3
                   type: string
@@ -2281,7 +2438,8 @@ paths:
           required: true
           schema:
             description: The voice profile id
-            example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+            examples:
+              - a1b2c3d4-e5f6-7890-1234-567890abcdef
             type: string
       responses:
         "200":
@@ -2312,7 +2470,8 @@ paths:
           required: true
           schema:
             description: The voice profile id
-            example: a1b2c3d4-e5f6-7890-1234-567890abcdef
+            examples:
+              - a1b2c3d4-e5f6-7890-1234-567890abcdef
             type: string
       responses:
         "200":


### PR DESCRIPTION
## Summary
- update the CLI spec and SDK dependency to `mirako-go v1.2.1`, which includes avatar `supported_interactive_models`
- show supported interactive models in `mirako avatar list` and `mirako avatar view`
- add formatter coverage and verify the CLI with `go vet`, `go test -v ./...`, and `go build -o mirako-cli ./cmd/mirako/main.go`