### PR TITLE
feat: add CLI self update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,18 @@ MIRAKO_DEBUG        # Enable debug mode
 | `--config` | Custom config file | `--config /path/to/config.yml` |
 | `--debug` | Enable debug mode | `--debug` |
 
+### Update Commands
+
+```bash
+# Check whether a newer CLI release is available
+mirako update --check
+
+# Update Mirako CLI to the latest release
+mirako update
+```
+
+`mirako --version` also shows a concise update hint when a newer release is available.
+
 ### Avatar Commands
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/mod v0.17.0
 )
 
 require (
@@ -54,7 +55,6 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/term v0.20.0 // indirect
 	golang.org/x/text v0.18.0 // indirect

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,521 @@
+package updater
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/semver"
+)
+
+const (
+	// DefaultLatestReleaseURL is the GitHub API endpoint used to discover the latest CLI release.
+	DefaultLatestReleaseURL = "https://api.github.com/repos/mirako-ai/mirako-cli/releases/latest"
+	defaultUserAgent        = "mirako-cli-updater"
+)
+
+var (
+	// ErrDevelopmentBuild is returned when the current binary is not a release build.
+	ErrDevelopmentBuild = errors.New("development build cannot be updated automatically")
+	// ErrHomebrewManaged is returned when the binary appears to be managed by Homebrew.
+	ErrHomebrewManaged = errors.New("homebrew-managed installation")
+)
+
+// Options configures update checks and installation.
+type Options struct {
+	HTTPClient       *http.Client
+	LatestReleaseURL string
+	GOOS             string
+	GOARCH           string
+	ExecutablePath   string
+}
+
+// Asset is a downloadable release asset.
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// Release contains the release metadata needed by the updater.
+type Release struct {
+	TagName string  `json:"tag_name"`
+	Assets  []Asset `json:"assets"`
+}
+
+// CheckResult describes the current and latest release state.
+type CheckResult struct {
+	CurrentVersion string
+	LatestVersion  string
+	LatestTag      string
+	Newer          bool
+	Release        Release
+}
+
+func (o Options) withDefaults() Options {
+	if o.HTTPClient == nil {
+		o.HTTPClient = http.DefaultClient
+	}
+	if o.LatestReleaseURL == "" {
+		o.LatestReleaseURL = DefaultLatestReleaseURL
+	}
+	if o.GOOS == "" {
+		o.GOOS = runtime.GOOS
+	}
+	if o.GOARCH == "" {
+		o.GOARCH = runtime.GOARCH
+	}
+	return o
+}
+
+// NormalizeVersion converts release versions like "1.2" or "v1.2.3" into valid semver strings.
+func NormalizeVersion(version string) (string, error) {
+	v := strings.TrimSpace(version)
+	if v == "" || strings.EqualFold(v, "dev") {
+		return "", ErrDevelopmentBuild
+	}
+
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+
+	coreEnd := len(v)
+	if idx := strings.IndexAny(v, "-+"); idx >= 0 {
+		coreEnd = idx
+	}
+	core := v[:coreEnd]
+	suffix := v[coreEnd:]
+
+	switch strings.Count(core, ".") {
+	case 0:
+		v = core + ".0.0" + suffix
+	case 1:
+		v = core + ".0" + suffix
+	}
+
+	if !semver.IsValid(v) {
+		return "", fmt.Errorf("invalid version %q", version)
+	}
+
+	return v, nil
+}
+
+// DisplayVersion removes the leading "v" from a normalized version for user-facing output.
+func DisplayVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
+}
+
+// IsNewerVersion reports whether latest is newer than current.
+func IsNewerVersion(current, latest string) (bool, error) {
+	currentNormalized, err := NormalizeVersion(current)
+	if err != nil {
+		return false, err
+	}
+	latestNormalized, err := NormalizeVersion(latest)
+	if err != nil {
+		return false, err
+	}
+	return semver.Compare(latestNormalized, currentNormalized) > 0, nil
+}
+
+// FetchLatestRelease retrieves the latest release metadata.
+func FetchLatestRelease(ctx context.Context, opts Options) (Release, error) {
+	opts = opts.withDefaults()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, opts.LatestReleaseURL, nil)
+	if err != nil {
+		return Release{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", defaultUserAgent)
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return Release{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return Release{}, fmt.Errorf("failed to fetch latest release: HTTP %d %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return Release{}, fmt.Errorf("failed to decode latest release: %w", err)
+	}
+	if release.TagName == "" {
+		return Release{}, errors.New("latest release response did not include tag_name")
+	}
+
+	return release, nil
+}
+
+// CheckForUpdate checks GitHub releases and reports whether a newer version is available.
+func CheckForUpdate(ctx context.Context, currentVersion string, opts Options) (CheckResult, error) {
+	currentNormalized, err := NormalizeVersion(currentVersion)
+	if err != nil {
+		return CheckResult{}, err
+	}
+
+	release, err := FetchLatestRelease(ctx, opts)
+	if err != nil {
+		return CheckResult{}, err
+	}
+
+	latestNormalized, err := NormalizeVersion(release.TagName)
+	if err != nil {
+		return CheckResult{}, fmt.Errorf("latest release has invalid version %q: %w", release.TagName, err)
+	}
+
+	return CheckResult{
+		CurrentVersion: DisplayVersion(currentNormalized),
+		LatestVersion:  DisplayVersion(latestNormalized),
+		LatestTag:      release.TagName,
+		Newer:          semver.Compare(latestNormalized, currentNormalized) > 0,
+		Release:        release,
+	}, nil
+}
+
+// AssetNameFor returns the release archive name and binary name for a platform.
+func AssetNameFor(goos, goarch string) (assetName, binaryName, archiveExt string, err error) {
+	var assetOS, assetArch string
+
+	switch goos {
+	case "darwin":
+		assetOS = "Darwin"
+		archiveExt = "tar.gz"
+	case "linux":
+		assetOS = "Linux"
+		archiveExt = "tar.gz"
+	case "windows":
+		assetOS = "Windows"
+		archiveExt = "zip"
+	default:
+		return "", "", "", fmt.Errorf("unsupported operating system: %s", goos)
+	}
+
+	switch goarch {
+	case "amd64":
+		assetArch = "x86_64"
+	case "arm64":
+		assetArch = "arm64"
+	default:
+		return "", "", "", fmt.Errorf("unsupported architecture: %s", goarch)
+	}
+
+	if goos == "windows" && goarch == "arm64" {
+		return "", "", "", errors.New("Windows arm64 is not published yet")
+	}
+
+	binaryName = "mirako"
+	if goos == "windows" {
+		binaryName += ".exe"
+	}
+
+	assetName = fmt.Sprintf("mirako-cli_%s_%s.%s", assetOS, assetArch, archiveExt)
+	return assetName, binaryName, archiveExt, nil
+}
+
+func findAsset(release Release, name string) (Asset, bool) {
+	for _, asset := range release.Assets {
+		if asset.Name == name {
+			return asset, true
+		}
+	}
+	return Asset{}, false
+}
+
+// InstallLatest downloads, verifies, extracts, and replaces the current executable with the latest release.
+func InstallLatest(ctx context.Context, currentVersion string, opts Options, out io.Writer) (CheckResult, error) {
+	if out == nil {
+		out = io.Discard
+	}
+	opts = opts.withDefaults()
+
+	result, err := CheckForUpdate(ctx, currentVersion, opts)
+	if err != nil {
+		return CheckResult{}, err
+	}
+	if !result.Newer {
+		return result, nil
+	}
+
+	executablePath, err := resolveExecutablePath(opts.ExecutablePath)
+	if err != nil {
+		return result, err
+	}
+	if IsHomebrewManaged(executablePath) {
+		return result, fmt.Errorf("%w: %s", ErrHomebrewManaged, executablePath)
+	}
+
+	assetName, binaryName, archiveExt, err := AssetNameFor(opts.GOOS, opts.GOARCH)
+	if err != nil {
+		return result, err
+	}
+
+	asset, ok := findAsset(result.Release, assetName)
+	if !ok {
+		return result, fmt.Errorf("release %s does not include asset %s", result.LatestTag, assetName)
+	}
+	checksumsAsset, ok := findAsset(result.Release, "checksums.txt")
+	if !ok {
+		return result, fmt.Errorf("release %s does not include checksums.txt", result.LatestTag)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "mirako-update-*")
+	if err != nil {
+		return result, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	archivePath := filepath.Join(tmpDir, assetName)
+	checksumsPath := filepath.Join(tmpDir, "checksums.txt")
+	extractedPath := filepath.Join(tmpDir, binaryName)
+
+	fmt.Fprintf(out, "Current version: %s\n", result.CurrentVersion)
+	fmt.Fprintf(out, "Latest version: %s\n", result.LatestVersion)
+	fmt.Fprintf(out, "Downloading %s...\n", assetName)
+	if err := downloadFile(ctx, opts.HTTPClient, asset.BrowserDownloadURL, archivePath); err != nil {
+		return result, err
+	}
+	if err := downloadFile(ctx, opts.HTTPClient, checksumsAsset.BrowserDownloadURL, checksumsPath); err != nil {
+		return result, err
+	}
+
+	fmt.Fprintln(out, "Verifying checksum...")
+	if err := verifyChecksumFile(archivePath, checksumsPath, assetName); err != nil {
+		return result, err
+	}
+
+	if err := extractBinary(archivePath, archiveExt, binaryName, extractedPath); err != nil {
+		return result, err
+	}
+
+	fmt.Fprintf(out, "Installing to %s...\n", executablePath)
+	if err := replaceExecutable(extractedPath, executablePath); err != nil {
+		return result, err
+	}
+
+	fmt.Fprintf(out, "Updated Mirako CLI to %s\n", result.LatestVersion)
+	return result, nil
+}
+
+// IsHomebrewManaged reports whether the executable path appears to be under a Homebrew Cellar.
+func IsHomebrewManaged(executablePath string) bool {
+	path := filepath.ToSlash(executablePath)
+	return strings.Contains(path, "/Cellar/mirako/") || strings.Contains(path, "/Cellar/mirako-cli/")
+}
+
+func resolveExecutablePath(path string) (string, error) {
+	if path == "" {
+		executablePath, err := os.Executable()
+		if err != nil {
+			return "", fmt.Errorf("failed to determine current executable path: %w", err)
+		}
+		path = executablePath
+	}
+
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return filepath.Abs(path)
+}
+
+func downloadFile(ctx context.Context, client *http.Client, url, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", defaultUserAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("failed to download %s: HTTP %d %s", url, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, resp.Body)
+	return err
+}
+
+func verifyChecksumFile(archivePath, checksumsPath, assetName string) error {
+	contents, err := os.ReadFile(checksumsPath)
+	if err != nil {
+		return err
+	}
+
+	expected, err := expectedChecksum(contents, assetName)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return err
+	}
+
+	actual := hex.EncodeToString(hash.Sum(nil))
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("checksum verification failed for %s", assetName)
+	}
+	return nil
+}
+
+func expectedChecksum(contents []byte, assetName string) (string, error) {
+	for _, line := range strings.Split(string(contents), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[len(fields)-1] == assetName {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("checksum for %s was not found", assetName)
+}
+
+func extractBinary(archivePath, archiveExt, binaryName, destPath string) error {
+	switch archiveExt {
+	case "tar.gz":
+		return extractBinaryFromTarGz(archivePath, binaryName, destPath)
+	case "zip":
+		return extractBinaryFromZip(archivePath, binaryName, destPath)
+	default:
+		return fmt.Errorf("unsupported archive format: %s", archiveExt)
+	}
+}
+
+func extractBinaryFromTarGz(archivePath, binaryName, destPath string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if header.Typeflag != tar.TypeReg || filepath.Base(header.Name) != binaryName {
+			continue
+		}
+		return writeExecutable(destPath, tarReader)
+	}
+
+	return fmt.Errorf("archive did not contain %s", binaryName)
+}
+
+func extractBinaryFromZip(archivePath, binaryName, destPath string) error {
+	zipReader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer zipReader.Close()
+
+	for _, file := range zipReader.File {
+		if file.FileInfo().IsDir() || filepath.Base(file.Name) != binaryName {
+			continue
+		}
+
+		reader, err := file.Open()
+		if err != nil {
+			return err
+		}
+		defer reader.Close()
+		return writeExecutable(destPath, reader)
+	}
+
+	return fmt.Errorf("archive did not contain %s", binaryName)
+}
+
+func writeExecutable(path string, reader io.Reader) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(file, reader); err != nil {
+		return err
+	}
+	return file.Chmod(0755)
+}
+
+func replaceExecutable(sourcePath, targetPath string) error {
+	dir := filepath.Dir(targetPath)
+	tmpFile, err := os.CreateTemp(dir, ".mirako-update-*")
+	if err != nil {
+		return fmt.Errorf("cannot write to %s: %w", dir, err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	defer source.Close()
+
+	if _, err := io.Copy(tmpFile, source); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Chmod(0755); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		return fmt.Errorf("failed to replace %s: %w", targetPath, err)
+	}
+	return nil
+}
+
+// CheckWithTimeout is a convenience wrapper for short, best-effort update checks.
+func CheckWithTimeout(currentVersion string, timeout time.Duration) (CheckResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return CheckForUpdate(ctx, currentVersion, Options{})
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,274 @@
+package updater
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{name: "full without v", input: "1.2.3", expected: "v1.2.3"},
+		{name: "full with v", input: "v1.2.3", expected: "v1.2.3"},
+		{name: "minor version", input: "1.2", expected: "v1.2.0"},
+		{name: "major version", input: "v1", expected: "v1.0.0"},
+		{name: "prerelease", input: "1.2.3-beta.1", expected: "v1.2.3-beta.1"},
+		{name: "dev", input: "dev", wantErr: true},
+		{name: "invalid", input: "not-a-version", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := NormalizeVersion(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		latest   string
+		expected bool
+	}{
+		{name: "newer patch", current: "1.2.1", latest: "v1.2.2", expected: true},
+		{name: "same", current: "v1.2.1", latest: "1.2.1", expected: false},
+		{name: "older", current: "1.2.2", latest: "1.2.1", expected: false},
+		{name: "minor normalized", current: "1.1", latest: "1.1.1", expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := IsNewerVersion(tt.current, tt.latest)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestAssetNameFor(t *testing.T) {
+	tests := []struct {
+		name       string
+		goos       string
+		goarch     string
+		assetName  string
+		binaryName string
+		archiveExt string
+		wantErr    bool
+	}{
+		{name: "darwin arm64", goos: "darwin", goarch: "arm64", assetName: "mirako-cli_Darwin_arm64.tar.gz", binaryName: "mirako", archiveExt: "tar.gz"},
+		{name: "linux amd64", goos: "linux", goarch: "amd64", assetName: "mirako-cli_Linux_x86_64.tar.gz", binaryName: "mirako", archiveExt: "tar.gz"},
+		{name: "windows amd64", goos: "windows", goarch: "amd64", assetName: "mirako-cli_Windows_x86_64.zip", binaryName: "mirako.exe", archiveExt: "zip"},
+		{name: "unsupported os", goos: "freebsd", goarch: "amd64", wantErr: true},
+		{name: "unsupported arch", goos: "linux", goarch: "386", wantErr: true},
+		{name: "windows arm64", goos: "windows", goarch: "arm64", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assetName, binaryName, archiveExt, err := AssetNameFor(tt.goos, tt.goarch)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.assetName, assetName)
+			assert.Equal(t, tt.binaryName, binaryName)
+			assert.Equal(t, tt.archiveExt, archiveExt)
+		})
+	}
+}
+
+func TestCheckForUpdate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/latest", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(Release{TagName: "v1.2.2"})
+	}))
+	defer server.Close()
+
+	result, err := CheckForUpdate(context.Background(), "1.2.1", Options{
+		HTTPClient:       server.Client(),
+		LatestReleaseURL: server.URL + "/latest",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Newer)
+	assert.Equal(t, "1.2.1", result.CurrentVersion)
+	assert.Equal(t, "1.2.2", result.LatestVersion)
+}
+
+func TestCheckForUpdateAlreadyLatest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(Release{TagName: "v1.2.1"})
+	}))
+	defer server.Close()
+
+	result, err := CheckForUpdate(context.Background(), "1.2.1", Options{
+		HTTPClient:       server.Client(),
+		LatestReleaseURL: server.URL,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.Newer)
+}
+
+func TestCheckForUpdateDevelopmentBuild(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	_, err := CheckForUpdate(context.Background(), "dev", Options{
+		HTTPClient:       server.Client(),
+		LatestReleaseURL: server.URL,
+	})
+	require.ErrorIs(t, err, ErrDevelopmentBuild)
+	assert.False(t, called)
+}
+
+func TestInstallLatest(t *testing.T) {
+	assetName, _, _, err := AssetNameFor("linux", "amd64")
+	require.NoError(t, err)
+
+	archive := tarGzArchive(t, "mirako", []byte("#!/bin/sh\necho new\n"))
+	checksum := sha256.Sum256(archive)
+	checksums := []byte(fmt.Sprintf("%s  %s\n", hex.EncodeToString(checksum[:]), assetName))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/latest":
+			_ = json.NewEncoder(w).Encode(Release{
+				TagName: "v1.2.0",
+				Assets: []Asset{
+					{Name: assetName, BrowserDownloadURL: "http://" + r.Host + "/" + assetName},
+					{Name: "checksums.txt", BrowserDownloadURL: "http://" + r.Host + "/checksums.txt"},
+				},
+			})
+		case "/" + assetName:
+			_, _ = w.Write(archive)
+		case "/checksums.txt":
+			_, _ = w.Write(checksums)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "mirako")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0755))
+
+	var output bytes.Buffer
+	result, err := InstallLatest(context.Background(), "1.1.0", Options{
+		HTTPClient:       server.Client(),
+		LatestReleaseURL: server.URL + "/latest",
+		GOOS:             "linux",
+		GOARCH:           "amd64",
+		ExecutablePath:   target,
+	}, &output)
+	require.NoError(t, err)
+	assert.True(t, result.Newer)
+	assert.Contains(t, output.String(), "Updated Mirako CLI to 1.2.0")
+
+	installed, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/sh\necho new\n", string(installed))
+}
+
+func TestInstallLatestChecksumMismatch(t *testing.T) {
+	assetName, _, _, err := AssetNameFor("linux", "amd64")
+	require.NoError(t, err)
+
+	archive := tarGzArchive(t, "mirako", []byte("new"))
+	checksums := []byte(fmt.Sprintf("%064x  %s\n", 0, assetName))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/latest":
+			_ = json.NewEncoder(w).Encode(Release{
+				TagName: "v1.2.0",
+				Assets: []Asset{
+					{Name: assetName, BrowserDownloadURL: "http://" + r.Host + "/" + assetName},
+					{Name: "checksums.txt", BrowserDownloadURL: "http://" + r.Host + "/checksums.txt"},
+				},
+			})
+		case "/" + assetName:
+			_, _ = w.Write(archive)
+		case "/checksums.txt":
+			_, _ = w.Write(checksums)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	target := filepath.Join(t.TempDir(), "mirako")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0755))
+
+	_, err = InstallLatest(context.Background(), "1.1.0", Options{
+		HTTPClient:       server.Client(),
+		LatestReleaseURL: server.URL + "/latest",
+		GOOS:             "linux",
+		GOARCH:           "amd64",
+		ExecutablePath:   target,
+	}, ioDiscard{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum verification failed")
+
+	installed, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old", string(installed))
+}
+
+func TestIsHomebrewManaged(t *testing.T) {
+	assert.True(t, IsHomebrewManaged("/opt/homebrew/Cellar/mirako/1.2.1/bin/mirako"))
+	assert.True(t, IsHomebrewManaged("/usr/local/Cellar/mirako-cli/1.2.1/bin/mirako"))
+	assert.False(t, IsHomebrewManaged("/Users/me/.mirako/bin/mirako"))
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) { return len(p), nil }
+
+func tarGzArchive(t *testing.T, name string, contents []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0755,
+		Size: int64(len(contents)),
+	}))
+	_, err := tarWriter.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+
+	return buf.Bytes()
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -1,10 +1,13 @@
 package root
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/mirako-ai/mirako-cli/internal/config"
+	"github.com/mirako-ai/mirako-cli/internal/updater"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/auth"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/avatar"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/completion"
@@ -12,6 +15,7 @@ import (
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/image"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/interactive"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/speech"
+	updatecmd "github.com/mirako-ai/mirako-cli/pkg/cmd/update"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/video"
 	"github.com/mirako-ai/mirako-cli/pkg/cmd/voice"
 	"github.com/spf13/cobra"
@@ -44,11 +48,40 @@ For more information, visit: https://mirako.ai`,
 }
 
 func Execute() error {
+	rootCmd.Version = versionStringForArgs(os.Args[1:])
 	return rootCmd.Execute()
 }
 
 func getVersionString() string {
 	return Version
+}
+
+func versionStringForArgs(args []string) string {
+	version := getVersionString()
+	if !isRootVersionRequest(args) {
+		return version
+	}
+
+	if hint := updateHint(version); hint != "" {
+		return version + "\n" + hint
+	}
+	return version
+}
+
+func isRootVersionRequest(args []string) bool {
+	return len(args) == 1 && (args[0] == "--version" || args[0] == "-v")
+}
+
+func updateHint(currentVersion string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	result, err := updater.CheckForUpdate(ctx, currentVersion, updater.Options{})
+	if err != nil || !result.Newer {
+		return ""
+	}
+
+	return fmt.Sprintf("Update available: %s. Run `mirako update`.", result.LatestVersion)
 }
 
 func init() {
@@ -69,6 +102,7 @@ func init() {
 	rootCmd.AddCommand(image.NewImageCmd())
 	rootCmd.AddCommand(interactive.NewInteractiveCmd())
 	rootCmd.AddCommand(speech.NewSpeechCmd())
+	rootCmd.AddCommand(updatecmd.NewUpdateCmd(func() string { return Version }))
 	rootCmd.AddCommand(video.NewVideoCmd())
 	rootCmd.AddCommand(voice.NewVoiceCmd())
 }

--- a/pkg/cmd/root/version_test.go
+++ b/pkg/cmd/root/version_test.go
@@ -1,0 +1,27 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRootVersionRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{name: "long version", args: []string{"--version"}, expected: true},
+		{name: "short version", args: []string{"-v"}, expected: true},
+		{name: "no args", args: nil, expected: false},
+		{name: "subcommand flag", args: []string{"speech", "tts", "-v", "voice-id"}, expected: false},
+		{name: "version with other flag", args: []string{"--debug", "--version"}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isRootVersionRequest(tt.args))
+		})
+	}
+}

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -1,0 +1,73 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mirako-ai/mirako-cli/internal/updater"
+	"github.com/spf13/cobra"
+)
+
+const updateTimeout = 5 * time.Minute
+
+// NewUpdateCmd creates the update command.
+func NewUpdateCmd(currentVersion func() string) *cobra.Command {
+	var checkOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update Mirako CLI to the latest version",
+		Long:  "Check GitHub releases and update the current Mirako CLI executable to the latest version.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			version := currentVersion()
+			ctx, cancel := context.WithTimeout(cmd.Context(), updateTimeout)
+			defer cancel()
+
+			if checkOnly {
+				result, err := updater.CheckForUpdate(ctx, version, updater.Options{})
+				if err != nil {
+					return friendlyUpdateError(err)
+				}
+				if !result.Newer {
+					fmt.Fprintf(cmd.OutOrStdout(), "Mirako CLI is up to date: %s\n", result.CurrentVersion)
+					return nil
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Update available: %s (current: %s)\n", result.LatestVersion, result.CurrentVersion)
+				fmt.Fprintln(cmd.OutOrStdout(), "Run: mirako update")
+				return nil
+			}
+
+			executablePath, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("failed to determine current executable path: %w", err)
+			}
+
+			result, err := updater.InstallLatest(ctx, version, updater.Options{ExecutablePath: executablePath}, cmd.OutOrStdout())
+			if err != nil {
+				return friendlyUpdateError(err)
+			}
+			if !result.Newer {
+				fmt.Fprintf(cmd.OutOrStdout(), "Mirako CLI is already up to date: %s\n", result.CurrentVersion)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "Only check whether an update is available")
+
+	return cmd
+}
+
+func friendlyUpdateError(err error) error {
+	if errors.Is(err, updater.ErrDevelopmentBuild) {
+		return fmt.Errorf("this is a development build and cannot be updated automatically")
+	}
+	if errors.Is(err, updater.ErrHomebrewManaged) {
+		return fmt.Errorf("this Mirako CLI installation appears to be managed by Homebrew\nUpdate with: brew upgrade mirako-ai/tap/mirako")
+	}
+	return err
+}

--- a/pkg/cmd/update/update_test.go
+++ b/pkg/cmd/update/update_test.go
@@ -1,0 +1,41 @@
+package update
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mirako-ai/mirako-cli/internal/updater"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFriendlyUpdateError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		contains string
+	}{
+		{
+			name:     "development build",
+			err:      updater.ErrDevelopmentBuild,
+			contains: "development build",
+		},
+		{
+			name:     "homebrew managed",
+			err:      updater.ErrHomebrewManaged,
+			contains: "brew upgrade mirako-ai/tap/mirako",
+		},
+		{
+			name:     "other error",
+			err:      errors.New("network failed"),
+			contains: "network failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := friendlyUpdateError(tt.err)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.contains)
+		})
+	}
+}


### PR DESCRIPTION
Add `mirako update` command to update the mirako binary to the latest version.

```bash
mirako update
``` 

Also check for updates when running `mirako --version` and prompt the user to update if a new version is available.
